### PR TITLE
Fix applying patch in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ RUN mkdir /src && \
 
 WORKDIR /src
 
-COPY ./no_avx_patch.diff /no_avx_patch.diff
-RUN patch -p0 < /no_avx_patch.diff
+COPY ./o2_patch.diff /o2_patch.diff
+RUN patch -p1 < /o2_patch.diff
 
 ARG NUM_JOBS=
 


### PR DESCRIPTION
The `patch` command in the Dockerfile is wrong. It does not match the file name and the prefixes of your new patches.