### PR TITLE
Updated Dockerfile to match official image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,14 +5,54 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
 
 jobs:
 
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        - include:
+            mongo_version: 6.0.2
+            platforms: |-
+              linux/amd64
+
+        - include:
+            mongo_version: 5.0.20
+            platforms: |-
+              linux/amd64
+              linux/arm64
 
     steps:
     - uses: actions/checkout@v3
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2.2.0
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2.9.1
+
+    - name: Login to Docker registry
+      uses: docker/login-action@v2.2.0
+      with:
+        registry: ${{ env.ORG_NAME }}
+        username: ${{ secrets.DOCKER_HUB_USER }}
+        password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+    - name: Build and push ${{ matrix.name }}
+      uses: docker/build-push-action@v4.1.1
+      with:
+        context: .
+        file: Dockerfile
+        platforms: ${{ matrix.platforms }}
+        build-args: -|
+          NUM_JOBS=8
+          MONGO_VERSION=${{ matrix.mongo_version }}
+        push: true
+        tags: ${{ secrets.DOCKER_HUB_USER }}/mongo-wo-avx:${{ matrix.mongo_version }}
+        labels: |
+          maintainer=${{ github.repository_owner }}
+          org.opencontainers.image.vendor=${{ github.repository_owner }}
+          org.opencontainers.image.revision=${{ github.sha }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - mongo_version: 6.0.2
+          - mongo_version: 6.0.9
             platforms: |-
               linux/amd64
           - mongo_version: 5.0.20
@@ -37,6 +37,13 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_HUB_USER }}
         password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+    - name: cleanup local FS before build
+      run: |
+        # Workaround to provide additional free space for testing.
+        #   https://github.com/actions/virtual-environments/issues/2840
+        sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
     - name: Build and push ${{ matrix.mongo_version }}
       uses: docker/build-push-action@v4.1.1

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -14,13 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        - include:
-            mongo_version: 6.0.2
+        include:
+          - mongo_version: 6.0.2
             platforms: |-
               linux/amd64
-
-        - include:
-            mongo_version: 5.0.20
+          - mongo_version: 5.0.20
             platforms: |-
               linux/amd64
               linux/arm64
@@ -37,11 +35,10 @@ jobs:
     - name: Login to Docker registry
       uses: docker/login-action@v2.2.0
       with:
-        registry: ${{ env.ORG_NAME }}
         username: ${{ secrets.DOCKER_HUB_USER }}
         password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
-    - name: Build and push ${{ matrix.name }}
+    - name: Build and push ${{ matrix.mongo_version }}
       uses: docker/build-push-action@v4.1.1
       with:
         context: .

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -51,7 +51,7 @@ jobs:
         context: .
         file: Dockerfile
         platforms: ${{ matrix.platforms }}
-        build-args: -|
+        build-args: |
           NUM_JOBS=2
           MONGO_VERSION=${{ matrix.mongo_version }}
         push: true

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -45,7 +45,7 @@ jobs:
         file: Dockerfile
         platforms: ${{ matrix.platforms }}
         build-args: -|
-          NUM_JOBS=8
+          NUM_JOBS=2
           MONGO_VERSION=${{ matrix.mongo_version }}
         push: true
         tags: ${{ secrets.DOCKER_HUB_USER }}/mongo-wo-avx:${{ matrix.mongo_version }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,12 +15,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - mongo_version: 7.0.12
-            platforms: |-
-              linux/amd64
-          - mongo_version: 6.0.16
-            platforms: |-
-              linux/amd64
+          #- mongo_version: 7.0.12
+          #  platforms: |-
+          #    linux/amd64
+          #- mongo_version: 6.0.16
+          #  platforms: |-
+          #    linux/amd64
           - mongo_version: 5.0.28
             platforms: |-
               linux/amd64

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,7 +11,7 @@ jobs:
 
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     strategy:
       matrix:
         include:
@@ -24,10 +24,12 @@ jobs:
           - mongo_version: 5.0.28
             platforms: |-
               linux/amd64
-              linux/arm64
+              #linux/arm64
+      fail-fast: true
+      max-parallel: 1
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2.2.0

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -55,7 +55,7 @@ jobs:
         file: Dockerfile
         platforms: ${{ matrix.platforms }}
         build-args: |
-          NUM_JOBS=2
+          NUM_JOBS=4
           MONGO_VERSION=${{ matrix.mongo_version }}
         push: true
         tags: ${{ secrets.DOCKER_HUB_USER }}/mongo-wo-avx:${{ matrix.mongo_version }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,10 +15,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - mongo_version: 6.0.9
+          - mongo_version: 7.0.12
             platforms: |-
               linux/amd64
-          - mongo_version: 5.0.20
+          - mongo_version: 6.0.16
+            platforms: |-
+              linux/amd64
+          - mongo_version: 5.0.28
             platforms: |-
               linux/amd64
               linux/arm64

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -57,7 +57,7 @@ jobs:
         file: Dockerfile
         platforms: ${{ matrix.platforms }}
         build-args: |
-          NUM_JOBS=4
+          NUM_JOBS=8
           MONGO_VERSION=${{ matrix.mongo_version }}
         push: true
         tags: ${{ secrets.DOCKER_HUB_USER }}/mongo-wo-avx:${{ matrix.mongo_version }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -43,12 +43,12 @@ jobs:
         username: ${{ secrets.DOCKER_HUB_USER }}
         password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
-    - name: cleanup local FS before build
-      run: |
-        # Workaround to provide additional free space for testing.
-        #   https://github.com/actions/virtual-environments/issues/2840
-        sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
-        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+    #- name: cleanup local FS before build
+    #  run: |
+    #    # Workaround to provide additional free space for testing.
+    #    #   https://github.com/actions/virtual-environments/issues/2840
+    #    sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
+    #    sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
     - name: Build and push ${{ matrix.mongo_version }}
       uses: docker/build-push-action@v7

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - mongo_version: 8.0.20
+          - mongo_version: 8.0.19
             platforms: |-
               linux/amd64
           #- mongo_version: 6.0.16

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -57,7 +57,7 @@ jobs:
         file: Dockerfile
         platforms: ${{ matrix.platforms }}
         build-args: |
-          NUM_JOBS=8
+          NUM_JOBS=12
           MONGO_VERSION=${{ matrix.mongo_version }}
         push: true
         tags: ${{ secrets.DOCKER_HUB_USER }}/mongo-wo-avx:${{ matrix.mongo_version }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,30 +15,30 @@ jobs:
     strategy:
       matrix:
         include:
-          #- mongo_version: 7.0.12
-          #  platforms: |-
-          #    linux/amd64
+          - mongo_version: 8.0.20
+            platforms: |-
+              linux/amd64
           #- mongo_version: 6.0.16
           #  platforms: |-
           #    linux/amd64
-          - mongo_version: 5.0.28
-            platforms: |-
-              linux/amd64
+          #- mongo_version: 5.0.28
+          #  platforms: |-
+          #    linux/amd64
               #linux/arm64
       fail-fast: true
       max-parallel: 1
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2.2.0
+      uses: docker/setup-qemu-action@v4
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2.9.1
+      uses: docker/setup-buildx-action@v4
 
     - name: Login to Docker registry
-      uses: docker/login-action@v2.2.0
+      uses: docker/login-action@v4
       with:
         username: ${{ secrets.DOCKER_HUB_USER }}
         password: ${{ secrets.DOCKER_HUB_TOKEN }}
@@ -51,7 +51,7 @@ jobs:
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
     - name: Build and push ${{ matrix.mongo_version }}
-      uses: docker/build-push-action@v4.1.1
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN export GIT_PYTHON_REFRESH=quiet && \
     python3 -m pip install requirements_parser && \
     python3 -m pip install -r etc/pip/compile-requirements.txt && \
     if [ "${NUM_JOBS}" -gt 0 ]; then export JOBS_ARG="-j ${NUM_JOBS}"; fi && \
-    python3 buildscripts/scons.py install-servers MONGO_VERSION="${MONGO_VERSION}" --release --disable-warnings-as-errors ${JOBS_ARG} && \
+    python3 buildscripts/scons.py install-devcore MONGO_VERSION="${MONGO_VERSION}" --release --disable-warnings-as-errors ${JOBS_ARG} && \
     mv build/install /install && \
     strip --strip-debug /install/bin/mongod && \
     strip --strip-debug /install/bin/mongos && \
@@ -42,10 +42,76 @@ RUN apt update -y && \
 
 COPY --from=build /install/bin/mongo* /usr/local/bin/
 
-RUN mkdir -p /data/db && \
-    chmod -R 750 /data && \
-    chown -R 999:999 /data
+# grab gosu for easy step-down from root (https://github.com/tianon/gosu/releases)
+ENV GOSU_VERSION 1.16
+# grab "js-yaml" for parsing mongod's YAML config files (https://github.com/nodeca/js-yaml/releases)
+ENV JSYAML_VERSION 3.13.1
 
-USER 999
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		ca-certificates \
+		gnupg \
+		jq \
+		numactl \
+		procps \
+	; \
+	rm -rf /var/lib/apt/lists/*
 
-ENTRYPOINT [ "/usr/local/bin/mongod" ]
+RUN set -ex; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		wget \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	\
+	wget -O /js-yaml.js "https://github.com/nodeca/js-yaml/raw/${JSYAML_VERSION}/dist/js-yaml.js"; \
+# TODO some sort of download verification here
+	\
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark > /dev/null; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	\
+# smoke test
+	chmod +x /usr/local/bin/gosu; \
+	gosu --version; \
+	gosu nobody true
+
+RUN mkdir /docker-entrypoint-initdb.d
+#RUN mkdir -p /data/db && \
+#    chmod -R 750 /data && \
+#    chown -R 999:999 /data
+
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+RUN set -eux; \
+	groupadd --gid 999 --system mongodb; \
+	useradd --uid 999 --system --gid mongodb --home-dir /data/db mongodb; \
+	mkdir -p /data/db /data/configdb; \
+	chown -R mongodb:mongodb /data/db /data/configdb
+
+USER mongodb
+
+VOLUME /data/db /data/configdb
+
+# ensure that if running as custom user that "mongosh" has a valid "HOME"
+# https://github.com/docker-library/mongo/issues/524
+ENV HOME /data/db
+
+COPY docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+EXPOSE 27017
+CMD ["mongod"]
+
+#ENTRYPOINT [ "/usr/local/bin/mongod" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,50 @@
-FROM debian:12 as build
+# MongoDB without AVX
+# Based on https://github.com/alanedwardes/mongodb-without-avx
+# Updated for MongoDB 8.x with Bazel build system
 
-RUN apt update -y && apt install -y build-essential \
+FROM debian:12 AS build
+
+# Install build dependencies for MongoDB 8.x with Bazel
+RUN apt-get update -y && apt-get install -y \
+        build-essential \
         libcurl4-openssl-dev \
         liblzma-dev \
         libssl-dev \
         python-dev-is-python3 \
         python3-pip \
+        python3-venv \
+        lld \
         curl \
+        git \
+        pkg-config \
+        openjdk-17-jdk \
     && rm -rf /var/lib/apt/lists/*
 
-ARG MONGO_VERSION=6.2.1
+ARG MONGO_VERSION=8.0.19
 
+# Download MongoDB source
 RUN mkdir /src && \
     curl -o /tmp/mongo.tar.gz -L "https://github.com/mongodb/mongo/archive/refs/tags/r${MONGO_VERSION}.tar.gz" && \
     tar xaf /tmp/mongo.tar.gz --strip-components=1 -C /src && \
     rm /tmp/mongo.tar.gz
 
 WORKDIR /src
+
+# Create stub enterprise directory structure to satisfy build dependencies
+# MongoDB's open source build has references to enterprise paths that need to exist
+RUN mkdir -p src/mongo/db/modules/enterprise/src/workloads/streams && \
+    echo '# Stub BUILD file for community build' > ls src/mongo/db/modules/enterprise/BUILD.bazel && \
+    echo '# Stub BUILD file for community build' > src/mongo/db/modules/enterprise/src/BUILD.bazel && \
+    echo '# Stub BUILD file for community build' > src/mongo/db/modules/enterprise/src/workloads/BUILD.bazel && \
+    echo '# Stub BUILD file for community build' > src/mongo/db/modules/enterprise/src/workloads/streams/BUILD.bazel
+
+# Install Bazelisk directly (handles correct Bazel version automatically)
+# This avoids needing MongoDB's install_bazel.py which has additional Python dependencies
+RUN mkdir -p /root/.local/bin && \
+    curl -L -o /root/.local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.25.0/bazelisk-linux-amd64 && \
+    chmod +x /root/.local/bin/bazel
+
+ENV PATH="/root/.local/bin:${PATH}"
 
 # Apply the no-AVX patch to disable sandybridge/AVX optimizations
 # The patch modifies bazel/toolchains/cc/mongo_linux/mongo_linux_cc_toolchain_config.bzl
@@ -29,95 +57,59 @@ RUN sed -i 's/-march=sandybridge", "-mtune=generic", "-mprefer-vector-width=128/
 
 ARG NUM_JOBS=
 
+# Build MongoDB using Bazel
+# --config=local disables remote execution (required for building outside MongoDB's infra)
+# --//bazel/config:build_enterprise=False explicitly disables enterprise modules
 RUN export GIT_PYTHON_REFRESH=quiet && \
-    python3 -m pip install --break-system-packages requirements_parser && \
-    python3 -m pip install --break-system-packages -r etc/pip/compile-requirements.txt && \
-    if [ "${NUM_JOBS}" -gt 0 ]; then export JOBS_ARG="-j ${NUM_JOBS}"; fi && \
-    python3 buildscripts/scons.py install-devcore MONGO_VERSION="${MONGO_VERSION}" --release --disable-warnings-as-errors ${JOBS_ARG} && \
-    mv build/install /install && \
-    strip --strip-debug /install/bin/mongod && \
-    strip --strip-debug /install/bin/mongos && \
-    rm -rf build
+    if [ -n "${NUM_JOBS}" ] && [ "${NUM_JOBS}" -gt 0 ]; then \
+        export JOBS_ARG="--jobs=${NUM_JOBS}"; \
+    fi && \
+    bazel build \
+        --config=local \
+        --//bazel/config:build_enterprise=False \
+        --disable_warnings_as_errors=True \
+        ${JOBS_ARG} \
+        //:install-mongod \
+        //:install-mongos
 
-FROM debian:12
+# Strip and prepare binaries
+RUN strip --strip-debug bazel-bin/install/bin/mongod && \
+    strip --strip-debug bazel-bin/install/bin/mongos && \
+    ls -la bazel-bin/install/bin/
 
-RUN apt update -y && \
-    apt install -y libcurl4 && \
-    apt-get clean \
+# Final image
+FROM debian:12-slim
+
+# Install runtime dependencies
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        libcurl4 \
+        libssl3 \
+        liblzma5 \
+        ca-certificates \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=build /install/bin/mongo* /usr/local/bin/
+# Copy MongoDB binaries
+COPY --from=build /src/bazel-bin/install/bin/mongod /usr/local/bin/
+COPY --from=build /src/bazel-bin/install/bin/mongos /usr/local/bin/
 
-# grab gosu for easy step-down from root (https://github.com/tianon/gosu/releases)
-ENV GOSU_VERSION 1.16
-# grab "js-yaml" for parsing mongod's YAML config files (https://github.com/nodeca/js-yaml/releases)
-ENV JSYAML_VERSION 3.13.1
+# Create data directory with proper permissions
+RUN mkdir -p /data/db /data/configdb && \
+    chmod -R 750 /data && \
+    chown -R 999:999 /data
 
-RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		ca-certificates \
-		gnupg \
-		jq \
-		numactl \
-		procps \
-	; \
-	rm -rf /var/lib/apt/lists/*
+# Create mongodb user
+RUN groupadd -r mongodb --gid=999 && \
+    useradd -r -g mongodb --uid=999 mongodb
 
-RUN set -ex; \
-	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		wget \
-	; \
-	rm -rf /var/lib/apt/lists/*; \
-	\
-	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
-	\
-	wget -O /js-yaml.js "https://github.com/nodeca/js-yaml/raw/${JSYAML_VERSION}/dist/js-yaml.js"; \
-# TODO some sort of download verification here
-	\
-	apt-mark auto '.*' > /dev/null; \
-	apt-mark manual $savedAptMark > /dev/null; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	\
-# smoke test
-	chmod +x /usr/local/bin/gosu; \
-	gosu --version; \
-	gosu nobody true
+# Set volume for data persistence
+VOLUME ["/data/db", "/data/configdb"]
 
-RUN mkdir /docker-entrypoint-initdb.d
-#RUN mkdir -p /data/db && \
-#    chmod -R 750 /data && \
-#    chown -R 999:999 /data
-
-# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN set -eux; \
-	groupadd --gid 999 --system mongodb; \
-	useradd --uid 999 --system --gid mongodb --home-dir /data/db mongodb; \
-	mkdir -p /data/db /data/configdb; \
-	chown -R mongodb:mongodb /data/db /data/configdb
+# Expose MongoDB default port
+EXPOSE 27017
 
 USER mongodb
 
-VOLUME /data/db /data/configdb
-
-# ensure that if running as custom user that "mongosh" has a valid "HOME"
-# https://github.com/docker-library/mongo/issues/524
-ENV HOME /data/db
-
-COPY docker-entrypoint.sh /usr/local/bin/
-ENTRYPOINT ["docker-entrypoint.sh"]
-
-EXPOSE 27017
-CMD ["mongod"]
-
-#ENTRYPOINT [ "/usr/local/bin/mongod" ]
+ENTRYPOINT ["/usr/local/bin/mongod"]
+CMD ["--bind_ip_all"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -144,7 +144,9 @@ RUN sed -i 's/-march=sandybridge", "-mtune=generic", "-mprefer-vector-width=128/
     echo "Patch applied. Checking file contents:" && \
     grep -n "march=" bazel/toolchains/cc/mongo_linux/mongo_linux_cc_toolchain_config.bzl || true
 
-ARG NUM_JOBS=
+# Override at build time with: docker build --build-arg NUM_JOBS=8
+# Defaults to nproc-1 (all CPUs minus one to keep the system responsive)
+ARG NUM_JOBS=0
 
 # Build MongoDB using Bazel
 # --config=local disables remote execution (required for building outside MongoDB's infra)
@@ -152,9 +154,14 @@ ARG NUM_JOBS=
 # --action_env flags pass the host CA bundle into sandboxed actions so pip/curl
 #   can verify TLS certificates when fetching Python wheels from PyPI
 RUN export GIT_PYTHON_REFRESH=quiet && \
-    if [ -n "${NUM_JOBS}" ] && [ "${NUM_JOBS}" -gt 0 ]; then \
-        export JOBS_ARG="--jobs=${NUM_JOBS}"; \
+    if [ "${NUM_JOBS}" -gt 0 ] 2>/dev/null; then \
+        RESOLVED_JOBS="${NUM_JOBS}"; \
+    else \
+        CPUS=$(nproc); \
+        RESOLVED_JOBS=$(( CPUS > 1 ? CPUS - 1 : 1 )); \
     fi && \
+    echo "Building with ${RESOLVED_JOBS} job(s) ($(nproc) CPUs available)" && \
+    export JOBS_ARG="--jobs=${RESOLVED_JOBS}" && \
     bazel build \
         --config=local \
         --//bazel/config:build_enterprise=False \

--- a/Dockerfile
+++ b/Dockerfile
@@ -173,6 +173,7 @@ RUN export GIT_PYTHON_REFRESH=quiet && \
         --disable_warnings_as_errors=True \
         --//bazel/config:debug_symbols=False \
         --//bazel/config:dbg=False \
+        --fission=no \
         --action_env=SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
         --action_env=SSL_CERT_DIR=/etc/ssl/certs \
         --action_env=REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ FROM debian:12 AS build
 # Install build dependencies for MongoDB 8.x with Bazel
 RUN apt-get update -y && apt-get install -y \
         build-essential \
+        ca-certificates \
         libcurl4-openssl-dev \
         liblzma-dev \
         libssl-dev \
@@ -73,6 +74,10 @@ RUN export GIT_PYTHON_REFRESH=quiet && \
         --config=local \
         --//bazel/config:build_enterprise=False \
         --disable_warnings_as_errors=True \
+        --action_env=SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
+        --action_env=SSL_CERT_DIR=/etc/ssl/certs \
+        --action_env=REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
+        --action_env=CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
         ${JOBS_ARG} \
         //:install-mongod \
         //:install-mongos

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 FROM debian:12 AS build
 
 # Install build dependencies for MongoDB 8.x with Bazel
-RUN apt-get update -y && apt-get install -y \
+RUN apt-get update -y && apt-get install --no-install-recommends -y \
         build-essential \
         ca-certificates \
         libcurl4-openssl-dev \
@@ -31,18 +31,45 @@ RUN mkdir /src && \
 
 WORKDIR /src
 
-# Create stub enterprise directory structure to satisfy build dependencies
-# MongoDB's open source build has references to enterprise paths that need to exist.
-# The 'docs' subdirectory is also referenced by //src:core_headers_library_with_debug
-# and must have a stub BUILD file too.
-RUN mkdir -p \
-        src/mongo/db/modules/enterprise/src/workloads/streams \
-        src/mongo/db/modules/enterprise/docs && \
-    echo '# Stub BUILD file for community build' > src/mongo/db/modules/enterprise/BUILD.bazel && \
-    echo '# Stub BUILD file for community build' > src/mongo/db/modules/enterprise/src/BUILD.bazel && \
-    echo '# Stub BUILD file for community build' > src/mongo/db/modules/enterprise/src/workloads/BUILD.bazel && \
-    echo '# Stub BUILD file for community build' > src/mongo/db/modules/enterprise/src/workloads/streams/BUILD.bazel && \
-    echo '# Stub BUILD file for community build' > src/mongo/db/modules/enterprise/docs/BUILD.bazel
+# Create stub enterprise directory structure to satisfy build dependencies.
+#
+# src/BUILD.bazel references enterprise sub-packages (docs, queryable, etc.) even when
+# --//bazel/config:build_enterprise=False is set. The set of referenced paths changes
+# across patch releases, so instead of a fixed list we:
+#   1. Parse src/BUILD.bazel to find every enterprise sub-path it mentions, and
+#      stub each one automatically.
+#   2. Also stub a known fixed set as a safety net for paths not caught by grep.
+RUN set -e; \
+    ENTERPRISE_ROOT="src/mongo/db/modules/enterprise"; \
+    STUB='# Stub BUILD file for community build'; \
+    \
+    # Auto-discover every enterprise sub-path mentioned in src/BUILD.bazel
+    grep -oE 'src/mongo/db/modules/enterprise/[^"'\'' >]+' src/BUILD.bazel \
+        | sed 's|/[^/]*$||' \
+        | sort -u \
+        | while IFS= read -r subpath; do \
+            rel="${subpath#src/mongo/db/modules/enterprise/}"; \
+            fullpath="${ENTERPRISE_ROOT}/${rel}"; \
+            mkdir -p "${fullpath}"; \
+            printf '%s\n' "${STUB}" > "${fullpath}/BUILD.bazel"; \
+          done; \
+    \
+    # Fixed safety-net stubs (covers top-level + known subdirs across 8.x releases)
+    for d in \
+        "${ENTERPRISE_ROOT}" \
+        "${ENTERPRISE_ROOT}/src" \
+        "${ENTERPRISE_ROOT}/src/workloads" \
+        "${ENTERPRISE_ROOT}/src/workloads/streams" \
+        "${ENTERPRISE_ROOT}/docs" \
+        "${ENTERPRISE_ROOT}/src/queryable" \
+        "${ENTERPRISE_ROOT}/distsrc" \
+    ; do \
+        mkdir -p "${d}"; \
+        printf '%s\n' "${STUB}" > "${d}/BUILD.bazel"; \
+    done; \
+    \
+    echo "Stubbed enterprise directories:"; \
+    find "${ENTERPRISE_ROOT}" -name BUILD.bazel | sort
 
 # Install Bazelisk directly (handles correct Bazel version automatically)
 # This avoids needing MongoDB's install_bazel.py which has additional Python dependencies
@@ -66,6 +93,8 @@ ARG NUM_JOBS=
 # Build MongoDB using Bazel
 # --config=local disables remote execution (required for building outside MongoDB's infra)
 # --//bazel/config:build_enterprise=False explicitly disables enterprise modules
+# --action_env flags pass the host CA bundle into sandboxed actions so pip/curl
+#   can verify TLS certificates when fetching Python wheels from PyPI
 RUN export GIT_PYTHON_REFRESH=quiet && \
     if [ -n "${NUM_JOBS}" ] && [ "${NUM_JOBS}" -gt 0 ]; then \
         export JOBS_ARG="--jobs=${NUM_JOBS}"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,12 +31,17 @@ RUN mkdir /src && \
 WORKDIR /src
 
 # Create stub enterprise directory structure to satisfy build dependencies
-# MongoDB's open source build has references to enterprise paths that need to exist
-RUN mkdir -p src/mongo/db/modules/enterprise/src/workloads/streams && \
-    echo '# Stub BUILD file for community build' > ls src/mongo/db/modules/enterprise/BUILD.bazel && \
+# MongoDB's open source build has references to enterprise paths that need to exist.
+# The 'docs' subdirectory is also referenced by //src:core_headers_library_with_debug
+# and must have a stub BUILD file too.
+RUN mkdir -p \
+        src/mongo/db/modules/enterprise/src/workloads/streams \
+        src/mongo/db/modules/enterprise/docs && \
+    echo '# Stub BUILD file for community build' > src/mongo/db/modules/enterprise/BUILD.bazel && \
     echo '# Stub BUILD file for community build' > src/mongo/db/modules/enterprise/src/BUILD.bazel && \
     echo '# Stub BUILD file for community build' > src/mongo/db/modules/enterprise/src/workloads/BUILD.bazel && \
-    echo '# Stub BUILD file for community build' > src/mongo/db/modules/enterprise/src/workloads/streams/BUILD.bazel
+    echo '# Stub BUILD file for community build' > src/mongo/db/modules/enterprise/src/workloads/streams/BUILD.bazel && \
+    echo '# Stub BUILD file for community build' > src/mongo/db/modules/enterprise/docs/BUILD.bazel
 
 # Install Bazelisk directly (handles correct Bazel version automatically)
 # This avoids needing MongoDB's install_bazel.py which has additional Python dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -175,6 +175,7 @@ RUN export GIT_PYTHON_REFRESH=quiet && \
         --action_env=SSL_CERT_DIR=/etc/ssl/certs \
         --action_env=REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
         --action_env=CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
+        --//bazel/config:linkstatic=True \
         --define=MONGO_VERSION="${MONGO_VERSION}" \
         --define=GIT_COMMIT_HASH="0000000000000000000000000000000000000000" \
         ${JOBS_ARG} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,44 +31,60 @@ RUN mkdir /src && \
 
 WORKDIR /src
 
-# Tell Bazel to ignore the entire enterprise module tree.
+# Stub enterprise packages required by the community build.
 #
-# Even with --//bazel/config:build_enterprise=False, Bazel's analysis phase still
-# resolves every package path that appears in BUILD files across the whole source
-# tree -- including deeply nested enterprise sub-packages like docs/fle,
-# src/streams/management/tests, etc. These paths are sometimes constructed
-# dynamically in Starlark (loops, string concatenation) so no grep-based approach
-# can reliably enumerate all of them.
+# Even with --//bazel/config:build_enterprise=False, the analysis phase resolves
+# every package path referenced in BUILD files across the whole source tree.
+# Enterprise sub-packages are referenced but don't exist in the community tarball.
 #
-# .bazelignore is the correct solution: it prevents Bazel from ever traversing
-# the enterprise directory, so no missing-package errors can occur regardless of
-# which sub-paths are referenced or how they are constructed.
+# Neither .bazelignore nor grep-based enumeration works reliably:
+#   - .bazelignore translates to --deleted_packages internally, which still errors
+#     when a BUILD file depends on a deleted package.
+#   - grep misses paths constructed dynamically in Starlark.
 #
-# We still need the top-level BUILD.bazel and one stub src/BUILD.bazel so that
-# the //src/mongo/db/modules/enterprise and //src/mongo/db/modules/enterprise/src
-# Bazel package targets (referenced from the root BUILD.bazel) resolve cleanly,
-# but everything beneath them is ignored.
-RUN ENTERPRISE_ROOT="src/mongo/db/modules/enterprise"; \
-    mkdir -p "${ENTERPRISE_ROOT}/src"; \
-    printf '# Stub BUILD file for community build\n' > "${ENTERPRISE_ROOT}/BUILD.bazel"; \
-    printf '# Stub BUILD file for community build\n' > "${ENTERPRISE_ROOT}/src/BUILD.bazel"; \
+# Solution: run `bazel query` (analysis only, no compilation) in a retry loop.
+#   Each iteration collects every "no such package" error pointing at an enterprise
+#   path, creates a stub BUILD.bazel there, and retries until the query succeeds.
+#   This is guaranteed to terminate because each iteration stubs at least one new
+#   directory, and the total number of referenced packages is finite.
+RUN set -e; \
+    ENTERPRISE_ROOT="src/mongo/db/modules/enterprise"; \
+    STUB='# Stub BUILD file for community build'; \
+    mkdir -p "${ENTERPRISE_ROOT}"; \
+    printf '%s\n' "${STUB}" > "${ENTERPRISE_ROOT}/BUILD.bazel"; \
     \
-    # Append the enterprise subtree to .bazelignore (creating the file if absent).
-    # This stops Bazel from walking into the directory and demanding BUILD files
-    # for every sub-package it finds referenced in the community BUILD files.
-    printf '%s\n' "${ENTERPRISE_ROOT}/docs" \
-                  "${ENTERPRISE_ROOT}/distsrc" \
-                  "${ENTERPRISE_ROOT}/src/audit" \
-                  "${ENTERPRISE_ROOT}/src/fle" \
-                  "${ENTERPRISE_ROOT}/src/ldap" \
-                  "${ENTERPRISE_ROOT}/src/live_import" \
-                  "${ENTERPRISE_ROOT}/src/queryable" \
-                  "${ENTERPRISE_ROOT}/src/streams" \
-                  "${ENTERPRISE_ROOT}/src/workloads" \
-        >> .bazelignore; \
+    QUERY_FLAGS=" \
+        --config=local \
+        --//bazel/config:build_enterprise=False \
+        --keep_going \
+        --output=label"; \
     \
-    echo "Updated .bazelignore:"; \
-    cat .bazelignore
+    for attempt in $(seq 1 30); do \
+        echo "--- Stub attempt ${attempt} ---"; \
+        MISSING=$(bazel query ${QUERY_FLAGS} \
+            'deps(//:install-mongod) + deps(//:install-mongos)' 2>&1 \
+            | grep -oE "no such package '[^']+'" \
+            | grep -oE "'[^']+'" \
+            | tr -d "'" \
+            | grep 'enterprise' \
+            | sort -u) || true; \
+        \
+        if [ -z "${MISSING}" ]; then \
+            echo "All enterprise packages resolved after ${attempt} attempt(s)."; \
+            break; \
+        fi; \
+        \
+        echo "Stubbing missing packages:"; \
+        echo "${MISSING}"; \
+        echo "${MISSING}" | while IFS= read -r pkg; do \
+            dir="${pkg//\/\///}"; \
+            dir="$(echo "${pkg}" | tr ':' '/')"; \
+            mkdir -p "${dir}"; \
+            printf '%s\n' "${STUB}" > "${dir}/BUILD.bazel"; \
+        done; \
+    done; \
+    echo "Final enterprise stubs:"; \
+    find "${ENTERPRISE_ROOT}" -name BUILD.bazel | sort
 
 # Install Bazelisk directly (handles correct Bazel version automatically)
 # This avoids needing MongoDB's install_bazel.py which has additional Python dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -170,9 +170,8 @@ RUN export GIT_PYTHON_REFRESH=quiet && \
         --action_env=SSL_CERT_DIR=/etc/ssl/certs \
         --action_env=REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
         --action_env=CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
-        --//bazel/config:mongo_version="${MONGO_VERSION}" \
-        --//bazel/config:git_hash="0000000000000000000000000000000000000000" \
-        --//bazel/config:git_branch="r${MONGO_VERSION}" \
+        --define=MONGO_VERSION="${MONGO_VERSION}" \
+        --define=GIT_COMMIT_HASH="0000000000000000000000000000000000000000" \
         ${JOBS_ARG} \
         //:install-mongod \
         //:install-mongos

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ RUN mkdir /src && \
 
 WORKDIR /src
 
-COPY ./o2_patch.diff /o2_patch.diff
-RUN patch -p1 < /o2_patch.diff
+COPY ./mongo8_patch.diff /mongo8_patch.diff
+RUN patch -p1 < /mongo8_patch.diff
 
 ARG NUM_JOBS=
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -138,7 +138,7 @@ ENV PATH="/root/.local/bin:${PATH}"
 # Install Cheetah3 with its C extension for NameMapper, which is used by
 # Bazel's sandboxed Python actions during the build. Without the C extension
 # the build still works but emits a UserWarning about performance.
-RUN pip3 install --no-cache-dir CT3
+RUN pip3 install --break-system-packages --no-cache-dir CT3
 
 # Apply the no-AVX patch to disable sandybridge/AVX optimizations
 # The patch modifies bazel/toolchains/cc/mongo_linux/mongo_linux_cc_toolchain_config.bzl

--- a/Dockerfile
+++ b/Dockerfile
@@ -170,6 +170,9 @@ RUN export GIT_PYTHON_REFRESH=quiet && \
         --action_env=SSL_CERT_DIR=/etc/ssl/certs \
         --action_env=REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
         --action_env=CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
+        --//bazel/config:mongo_version="${MONGO_VERSION}" \
+        --//bazel/config:git_hash="0000000000000000000000000000000000000000" \
+        --//bazel/config:git_branch="r${MONGO_VERSION}" \
         ${JOBS_ARG} \
         //:install-mongod \
         //:install-mongos

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,28 @@
-FROM debian:11 as build
+# MongoDB without AVX
+# Based on https://github.com/alanedwardes/mongodb-without-avx
+# Updated for MongoDB 8.x with Bazel build system
 
-RUN apt update -y && apt install -y build-essential \
+FROM debian:12 AS build
+
+# Install build dependencies for MongoDB 8.x with Bazel
+RUN apt-get update -y && apt-get install -y \
+        build-essential \
         libcurl4-openssl-dev \
         liblzma-dev \
         libssl-dev \
         python-dev-is-python3 \
         python3-pip \
+        python3-venv \
+        lld \
         curl \
+        git \
+        pkg-config \
+        openjdk-17-jdk \
     && rm -rf /var/lib/apt/lists/*
 
-ARG MONGO_VERSION=6.2.1
+ARG MONGO_VERSION=8.0.19
 
+# Download MongoDB source
 RUN mkdir /src && \
     curl -o /tmp/mongo.tar.gz -L "https://github.com/mongodb/mongo/archive/refs/tags/r${MONGO_VERSION}.tar.gz" && \
     tar xaf /tmp/mongo.tar.gz --strip-components=1 -C /src && \
@@ -18,100 +30,86 @@ RUN mkdir /src && \
 
 WORKDIR /src
 
-COPY ./mongo8_patch.diff /mongo8_patch.diff
-RUN patch -p1 < /mongo8_patch.diff
+# Create stub enterprise directory structure to satisfy build dependencies
+# MongoDB's open source build has references to enterprise paths that need to exist
+RUN mkdir -p src/mongo/db/modules/enterprise/src/workloads/streams && \
+    echo '# Stub BUILD file for community build' > src/mongo/db/modules/enterprise/BUILD.bazel && \
+    echo '# Stub BUILD file for community build' > src/mongo/db/modules/enterprise/src/BUILD.bazel && \
+    echo '# Stub BUILD file for community build' > src/mongo/db/modules/enterprise/src/workloads/BUILD.bazel && \
+    echo '# Stub BUILD file for community build' > src/mongo/db/modules/enterprise/src/workloads/streams/BUILD.bazel
+
+# Install Bazelisk directly (handles correct Bazel version automatically)
+# This avoids needing MongoDB's install_bazel.py which has additional Python dependencies
+RUN mkdir -p /root/.local/bin && \
+    curl -L -o /root/.local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.25.0/bazelisk-linux-amd64 && \
+    chmod +x /root/.local/bin/bazel
+
+ENV PATH="/root/.local/bin:${PATH}"
+
+# Apply the no-AVX patch to disable sandybridge/AVX optimizations
+# The patch modifies bazel/toolchains/cc/mongo_linux/mongo_linux_cc_toolchain_config.bzl
+# to use -march=x86-64-v2 instead of -march=sandybridge
+# x86-64-v2 supports SSE4.2 and POPCNT but NOT AVX (compatible with pre-2011 CPUs)
+RUN sed -i 's/-march=sandybridge", "-mtune=generic", "-mprefer-vector-width=128/-march=x86-64-v2", "-mtune=generic/g' \
+    bazel/toolchains/cc/mongo_linux/mongo_linux_cc_toolchain_config.bzl && \
+    echo "Patch applied. Checking file contents:" && \
+    grep -n "march=" bazel/toolchains/cc/mongo_linux/mongo_linux_cc_toolchain_config.bzl || true
 
 ARG NUM_JOBS=
 
+# Build MongoDB using Bazel
+# --config=local disables remote execution (required for building outside MongoDB's infra)
+# --//bazel/config:build_enterprise=False explicitly disables enterprise modules
 RUN export GIT_PYTHON_REFRESH=quiet && \
-    python3 -m pip install requirements_parser && \
-    python3 -m pip install -r etc/pip/compile-requirements.txt && \
-    if [ "${NUM_JOBS}" -gt 0 ]; then export JOBS_ARG="-j ${NUM_JOBS}"; fi && \
-    python3 buildscripts/scons.py install-devcore MONGO_VERSION="${MONGO_VERSION}" --release --disable-warnings-as-errors ${JOBS_ARG} && \
-    mv build/install /install && \
-    strip --strip-debug /install/bin/mongod && \
-    strip --strip-debug /install/bin/mongos && \
-    rm -rf build
+    if [ -n "${NUM_JOBS}" ] && [ "${NUM_JOBS}" -gt 0 ]; then \
+        export JOBS_ARG="--jobs=${NUM_JOBS}"; \
+    fi && \
+    bazel build \
+        --config=local \
+        --//bazel/config:build_enterprise=False \
+        --disable_warnings_as_errors=True \
+        ${JOBS_ARG} \
+        //:install-mongod \
+        //:install-mongos
 
-FROM debian:11
+# Strip and prepare binaries
+RUN strip --strip-debug bazel-bin/install/bin/mongod && \
+    strip --strip-debug bazel-bin/install/bin/mongos && \
+    ls -la bazel-bin/install/bin/
 
-RUN apt update -y && \
-    apt install -y libcurl4 && \
-    apt-get clean \
+# Final image
+FROM debian:12-slim
+
+# Install runtime dependencies
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        libcurl4 \
+        libssl3 \
+        liblzma5 \
+        ca-certificates \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=build /install/bin/mongo* /usr/local/bin/
+# Copy MongoDB binaries
+COPY --from=build /src/bazel-bin/install/bin/mongod /usr/local/bin/
+COPY --from=build /src/bazel-bin/install/bin/mongos /usr/local/bin/
 
-# grab gosu for easy step-down from root (https://github.com/tianon/gosu/releases)
-ENV GOSU_VERSION 1.16
-# grab "js-yaml" for parsing mongod's YAML config files (https://github.com/nodeca/js-yaml/releases)
-ENV JSYAML_VERSION 3.13.1
+# Create data directory with proper permissions
+RUN mkdir -p /data/db /data/configdb && \
+    chmod -R 750 /data && \
+    chown -R 999:999 /data
 
-RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		ca-certificates \
-		gnupg \
-		jq \
-		numactl \
-		procps \
-	; \
-	rm -rf /var/lib/apt/lists/*
+# Create mongodb user
+RUN groupadd -r mongodb --gid=999 && \
+    useradd -r -g mongodb --uid=999 mongodb
 
-RUN set -ex; \
-	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		wget \
-	; \
-	rm -rf /var/lib/apt/lists/*; \
-	\
-	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
-	\
-	wget -O /js-yaml.js "https://github.com/nodeca/js-yaml/raw/${JSYAML_VERSION}/dist/js-yaml.js"; \
-# TODO some sort of download verification here
-	\
-	apt-mark auto '.*' > /dev/null; \
-	apt-mark manual $savedAptMark > /dev/null; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	\
-# smoke test
-	chmod +x /usr/local/bin/gosu; \
-	gosu --version; \
-	gosu nobody true
+# Set volume for data persistence
+VOLUME ["/data/db", "/data/configdb"]
 
-RUN mkdir /docker-entrypoint-initdb.d
-#RUN mkdir -p /data/db && \
-#    chmod -R 750 /data && \
-#    chown -R 999:999 /data
-
-# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN set -eux; \
-	groupadd --gid 999 --system mongodb; \
-	useradd --uid 999 --system --gid mongodb --home-dir /data/db mongodb; \
-	mkdir -p /data/db /data/configdb; \
-	chown -R mongodb:mongodb /data/db /data/configdb
+# Expose MongoDB default port
+EXPOSE 27017
 
 USER mongodb
 
-VOLUME /data/db /data/configdb
-
-# ensure that if running as custom user that "mongosh" has a valid "HOME"
-# https://github.com/docker-library/mongo/issues/524
-ENV HOME /data/db
-
-COPY docker-entrypoint.sh /usr/local/bin/
-ENTRYPOINT ["docker-entrypoint.sh"]
-
-EXPOSE 27017
-CMD ["mongod"]
-
-#ENTRYPOINT [ "/usr/local/bin/mongod" ]
+ENTRYPOINT ["/usr/local/bin/mongod"]
+CMD ["--bind_ip_all"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,8 @@ RUN sed -i 's/-march=sandybridge", "-mtune=generic", "-mprefer-vector-width=128/
 ARG NUM_JOBS=
 
 RUN export GIT_PYTHON_REFRESH=quiet && \
-    python3 -m pip install requirements_parser && \
-    python3 -m pip install -r etc/pip/compile-requirements.txt && \
+    python3 -m pip install --break-system-packages requirements_parser && \
+    python3 -m pip install --break-system-packages -r etc/pip/compile-requirements.txt && \
     if [ "${NUM_JOBS}" -gt 0 ]; then export JOBS_ARG="-j ${NUM_JOBS}"; fi && \
     python3 buildscripts/scons.py install-devcore MONGO_VERSION="${MONGO_VERSION}" --release --disable-warnings-as-errors ${JOBS_ARG} && \
     mv build/install /install && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,18 @@
 # Based on https://github.com/alanedwardes/mongodb-without-avx
 # Updated for MongoDB 8.x with Bazel build system
 
-FROM debian:12 AS build
+FROM ubuntu:20.04 AS build
 
 # Install build dependencies for MongoDB 8.x with Bazel
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
         build-essential \
         ca-certificates \
         libcurl4-openssl-dev \
         liblzma-dev \
         libssl-dev \
-        python-dev-is-python3 \
+        python3-dev \
         python3-pip \
         python3-venv \
         lld \
@@ -175,7 +177,6 @@ RUN export GIT_PYTHON_REFRESH=quiet && \
         --action_env=SSL_CERT_DIR=/etc/ssl/certs \
         --action_env=REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
         --action_env=CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
-        --//bazel/config:linkstatic=True \
         --define=MONGO_VERSION="${MONGO_VERSION}" \
         --define=GIT_COMMIT_HASH="0000000000000000000000000000000000000000" \
         ${JOBS_ARG} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,59 +31,44 @@ RUN mkdir /src && \
 
 WORKDIR /src
 
-# Create stub enterprise directory structure to satisfy build dependencies.
+# Tell Bazel to ignore the entire enterprise module tree.
 #
 # Even with --//bazel/config:build_enterprise=False, Bazel's analysis phase still
-# resolves every package path that appears anywhere in BUILD files across the whole
-# source tree. Those paths are not limited to src/BUILD.bazel -- nested BUILD files
-# reference deeper sub-packages like src/streams/management/tests.
+# resolves every package path that appears in BUILD files across the whole source
+# tree -- including deeply nested enterprise sub-packages like docs/fle,
+# src/streams/management/tests, etc. These paths are sometimes constructed
+# dynamically in Starlark (loops, string concatenation) so no grep-based approach
+# can reliably enumerate all of them.
 #
-# Strategy: grep ALL *.bazel and BUILD files in the repo for any enterprise path,
-# strip the filename to get the directory, and create a stub BUILD.bazel in each.
-# A fixed safety-net list covers the top-level and any paths missed by grep.
-RUN set -e; \
-    ENTERPRISE_ROOT="src/mongo/db/modules/enterprise"; \
-    STUB='# Stub BUILD file for community build'; \
+# .bazelignore is the correct solution: it prevents Bazel from ever traversing
+# the enterprise directory, so no missing-package errors can occur regardless of
+# which sub-paths are referenced or how they are constructed.
+#
+# We still need the top-level BUILD.bazel and one stub src/BUILD.bazel so that
+# the //src/mongo/db/modules/enterprise and //src/mongo/db/modules/enterprise/src
+# Bazel package targets (referenced from the root BUILD.bazel) resolve cleanly,
+# but everything beneath them is ignored.
+RUN ENTERPRISE_ROOT="src/mongo/db/modules/enterprise"; \
+    mkdir -p "${ENTERPRISE_ROOT}/src"; \
+    printf '# Stub BUILD file for community build\n' > "${ENTERPRISE_ROOT}/BUILD.bazel"; \
+    printf '# Stub BUILD file for community build\n' > "${ENTERPRISE_ROOT}/src/BUILD.bazel"; \
     \
-    # Scan every BUILD file in the repo for referenced enterprise sub-packages
-    grep -rhoE 'src/mongo/db/modules/enterprise/[^"'\'' >]+' \
-            --include='*.bazel' --include='BUILD' . \
-        | sed 's|/[^/]*$||' \
-        | sort -u \
-        | while IFS= read -r subpath; do \
-            # subpath may be relative or absolute-looking; normalise it
-            subpath="${subpath#./}"; \
-            rel="${subpath#src/mongo/db/modules/enterprise/}"; \
-            fullpath="${ENTERPRISE_ROOT}/${rel}"; \
-            mkdir -p "${fullpath}"; \
-            printf '%s\n' "${STUB}" > "${fullpath}/BUILD.bazel"; \
-          done; \
+    # Append the enterprise subtree to .bazelignore (creating the file if absent).
+    # This stops Bazel from walking into the directory and demanding BUILD files
+    # for every sub-package it finds referenced in the community BUILD files.
+    printf '%s\n' "${ENTERPRISE_ROOT}/docs" \
+                  "${ENTERPRISE_ROOT}/distsrc" \
+                  "${ENTERPRISE_ROOT}/src/audit" \
+                  "${ENTERPRISE_ROOT}/src/fle" \
+                  "${ENTERPRISE_ROOT}/src/ldap" \
+                  "${ENTERPRISE_ROOT}/src/live_import" \
+                  "${ENTERPRISE_ROOT}/src/queryable" \
+                  "${ENTERPRISE_ROOT}/src/streams" \
+                  "${ENTERPRISE_ROOT}/src/workloads" \
+        >> .bazelignore; \
     \
-    # Fixed safety-net: top-level + known subdirs across 8.x patch releases
-    for d in \
-        "${ENTERPRISE_ROOT}" \
-        "${ENTERPRISE_ROOT}/src" \
-        "${ENTERPRISE_ROOT}/src/workloads" \
-        "${ENTERPRISE_ROOT}/src/workloads/streams" \
-        "${ENTERPRISE_ROOT}/docs" \
-        "${ENTERPRISE_ROOT}/src/queryable" \
-        "${ENTERPRISE_ROOT}/src/streams" \
-        "${ENTERPRISE_ROOT}/src/streams/exec" \
-        "${ENTERPRISE_ROOT}/src/streams/management" \
-        "${ENTERPRISE_ROOT}/src/streams/management/tests" \
-        "${ENTERPRISE_ROOT}/src/streams/util" \
-        "${ENTERPRISE_ROOT}/src/audit" \
-        "${ENTERPRISE_ROOT}/src/fle" \
-        "${ENTERPRISE_ROOT}/src/ldap" \
-        "${ENTERPRISE_ROOT}/src/live_import" \
-        "${ENTERPRISE_ROOT}/distsrc" \
-    ; do \
-        mkdir -p "${d}"; \
-        printf '%s\n' "${STUB}" > "${d}/BUILD.bazel"; \
-    done; \
-    \
-    echo "Stubbed enterprise directories:"; \
-    find "${ENTERPRISE_ROOT}" -name BUILD.bazel | sort
+    echo "Updated .bazelignore:"; \
+    cat .bazelignore
 
 # Install Bazelisk directly (handles correct Bazel version automatically)
 # This avoids needing MongoDB's install_bazel.py which has additional Python dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 FROM debian:12 AS build
 
 # Install build dependencies for MongoDB 8.x with Bazel
-RUN apt-get update -y && apt-get install --no-install-recommends -y \
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
         build-essential \
         ca-certificates \
         libcurl4-openssl-dev \
@@ -33,28 +33,33 @@ WORKDIR /src
 
 # Create stub enterprise directory structure to satisfy build dependencies.
 #
-# src/BUILD.bazel references enterprise sub-packages (docs, queryable, etc.) even when
-# --//bazel/config:build_enterprise=False is set. The set of referenced paths changes
-# across patch releases, so instead of a fixed list we:
-#   1. Parse src/BUILD.bazel to find every enterprise sub-path it mentions, and
-#      stub each one automatically.
-#   2. Also stub a known fixed set as a safety net for paths not caught by grep.
+# Even with --//bazel/config:build_enterprise=False, Bazel's analysis phase still
+# resolves every package path that appears anywhere in BUILD files across the whole
+# source tree. Those paths are not limited to src/BUILD.bazel -- nested BUILD files
+# reference deeper sub-packages like src/streams/management/tests.
+#
+# Strategy: grep ALL *.bazel and BUILD files in the repo for any enterprise path,
+# strip the filename to get the directory, and create a stub BUILD.bazel in each.
+# A fixed safety-net list covers the top-level and any paths missed by grep.
 RUN set -e; \
     ENTERPRISE_ROOT="src/mongo/db/modules/enterprise"; \
     STUB='# Stub BUILD file for community build'; \
     \
-    # Auto-discover every enterprise sub-path mentioned in src/BUILD.bazel
-    grep -oE 'src/mongo/db/modules/enterprise/[^"'\'' >]+' src/BUILD.bazel \
+    # Scan every BUILD file in the repo for referenced enterprise sub-packages
+    grep -rhoE 'src/mongo/db/modules/enterprise/[^"'\'' >]+' \
+            --include='*.bazel' --include='BUILD' . \
         | sed 's|/[^/]*$||' \
         | sort -u \
         | while IFS= read -r subpath; do \
+            # subpath may be relative or absolute-looking; normalise it
+            subpath="${subpath#./}"; \
             rel="${subpath#src/mongo/db/modules/enterprise/}"; \
             fullpath="${ENTERPRISE_ROOT}/${rel}"; \
             mkdir -p "${fullpath}"; \
             printf '%s\n' "${STUB}" > "${fullpath}/BUILD.bazel"; \
           done; \
     \
-    # Fixed safety-net stubs (covers top-level + known subdirs across 8.x releases)
+    # Fixed safety-net: top-level + known subdirs across 8.x patch releases
     for d in \
         "${ENTERPRISE_ROOT}" \
         "${ENTERPRISE_ROOT}/src" \
@@ -62,6 +67,15 @@ RUN set -e; \
         "${ENTERPRISE_ROOT}/src/workloads/streams" \
         "${ENTERPRISE_ROOT}/docs" \
         "${ENTERPRISE_ROOT}/src/queryable" \
+        "${ENTERPRISE_ROOT}/src/streams" \
+        "${ENTERPRISE_ROOT}/src/streams/exec" \
+        "${ENTERPRISE_ROOT}/src/streams/management" \
+        "${ENTERPRISE_ROOT}/src/streams/management/tests" \
+        "${ENTERPRISE_ROOT}/src/streams/util" \
+        "${ENTERPRISE_ROOT}/src/audit" \
+        "${ENTERPRISE_ROOT}/src/fle" \
+        "${ENTERPRISE_ROOT}/src/ldap" \
+        "${ENTERPRISE_ROOT}/src/live_import" \
         "${ENTERPRISE_ROOT}/distsrc" \
     ; do \
         mkdir -p "${d}"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,63 +31,101 @@ RUN mkdir /src && \
 
 WORKDIR /src
 
-# Create stub BUILD files for every enterprise sub-package referenced by
-# src/BUILD.bazel:core_headers_library_with_debug. These paths exist in the
-# enterprise repo but not in the community tarball. The list was extracted
-# directly from src/BUILD.bazel in MongoDB 8.0.19.
-RUN set -e; \
-    STUB='# Stub BUILD file for community build'; \
-    for d in \
-        src/mongo/db/modules/enterprise \
-        src/mongo/db/modules/enterprise/docs \
-        src/mongo/db/modules/enterprise/docs/fle \
-        src/mongo/db/modules/enterprise/docs/testing \
-        src/mongo/db/modules/enterprise/src \
-        src/mongo/db/modules/enterprise/src/audit \
-        src/mongo/db/modules/enterprise/src/audit/logger \
-        src/mongo/db/modules/enterprise/src/audit/mongo \
-        src/mongo/db/modules/enterprise/src/audit/ocsf \
-        src/mongo/db/modules/enterprise/src/encryptdb \
-        src/mongo/db/modules/enterprise/src/fcbis \
-        src/mongo/db/modules/enterprise/src/fips \
-        src/mongo/db/modules/enterprise/src/fle \
-        src/mongo/db/modules/enterprise/src/fle/commands \
-        src/mongo/db/modules/enterprise/src/fle/lib \
-        src/mongo/db/modules/enterprise/src/fle/query_analysis \
-        src/mongo/db/modules/enterprise/src/fle/shell \
-        src/mongo/db/modules/enterprise/src/hot_backups \
-        src/mongo/db/modules/enterprise/src/inmemory \
-        src/mongo/db/modules/enterprise/src/kerberos \
-        src/mongo/db/modules/enterprise/src/kmip \
-        src/mongo/db/modules/enterprise/src/ldap \
-        src/mongo/db/modules/enterprise/src/ldap/connections \
-        src/mongo/db/modules/enterprise/src/ldap/name_mapping \
-        src/mongo/db/modules/enterprise/src/live_import \
-        src/mongo/db/modules/enterprise/src/live_import/commands \
-        src/mongo/db/modules/enterprise/src/magic_restore \
-        src/mongo/db/modules/enterprise/src/queryable \
-        src/mongo/db/modules/enterprise/src/queryable/blockstore \
-        src/mongo/db/modules/enterprise/src/queryable/queryable_wt \
-        src/mongo/db/modules/enterprise/src/sasl \
-        src/mongo/db/modules/enterprise/src/scripts \
-        src/mongo/db/modules/enterprise/src/serverless \
-        src/mongo/db/modules/enterprise/src/streams \
-        src/mongo/db/modules/enterprise/src/streams/commands \
-        src/mongo/db/modules/enterprise/src/streams/exec \
-        src/mongo/db/modules/enterprise/src/streams/exec/checkpoint \
-        src/mongo/db/modules/enterprise/src/streams/exec/tests \
-        src/mongo/db/modules/enterprise/src/streams/management \
-        src/mongo/db/modules/enterprise/src/streams/management/tests \
-        src/mongo/db/modules/enterprise/src/streams/tools \
-        src/mongo/db/modules/enterprise/src/streams/util \
-        src/mongo/db/modules/enterprise/src/streams/util/tests \
-        src/mongo/db/modules/enterprise/src/util \
-        src/mongo/db/modules/enterprise/src/workloads \
-        src/mongo/db/modules/enterprise/src/workloads/streams \
-    ; do \
-        mkdir -p "${d}"; \
-        printf '%s\n' "${STUB}" > "${d}/BUILD.bazel"; \
-    done
+# Create stub BUILD files for every enterprise package and target referenced by
+# src/BUILD.bazel:core_headers_library_with_debug. Each BUILD file declares the
+# exact filegroup targets Bazel expects. Extracted from src/BUILD.bazel in 8.0.19.
+RUN mkdir -p src/mongo/db/modules/enterprise \
+             src/mongo/db/modules/enterprise/docs \
+             src/mongo/db/modules/enterprise/docs/fle \
+             src/mongo/db/modules/enterprise/docs/testing \
+             src/mongo/db/modules/enterprise/src \
+             src/mongo/db/modules/enterprise/src/audit \
+             src/mongo/db/modules/enterprise/src/audit/logger \
+             src/mongo/db/modules/enterprise/src/audit/mongo \
+             src/mongo/db/modules/enterprise/src/audit/ocsf \
+             src/mongo/db/modules/enterprise/src/encryptdb \
+             src/mongo/db/modules/enterprise/src/fcbis \
+             src/mongo/db/modules/enterprise/src/fips \
+             src/mongo/db/modules/enterprise/src/fle \
+             src/mongo/db/modules/enterprise/src/fle/commands \
+             src/mongo/db/modules/enterprise/src/fle/lib \
+             src/mongo/db/modules/enterprise/src/fle/query_analysis \
+             src/mongo/db/modules/enterprise/src/fle/shell \
+             src/mongo/db/modules/enterprise/src/hot_backups \
+             src/mongo/db/modules/enterprise/src/inmemory \
+             src/mongo/db/modules/enterprise/src/kerberos \
+             src/mongo/db/modules/enterprise/src/kmip \
+             src/mongo/db/modules/enterprise/src/ldap \
+             src/mongo/db/modules/enterprise/src/ldap/connections \
+             src/mongo/db/modules/enterprise/src/ldap/name_mapping \
+             src/mongo/db/modules/enterprise/src/live_import \
+             src/mongo/db/modules/enterprise/src/live_import/commands \
+             src/mongo/db/modules/enterprise/src/magic_restore \
+             src/mongo/db/modules/enterprise/src/queryable \
+             src/mongo/db/modules/enterprise/src/queryable/blockstore \
+             src/mongo/db/modules/enterprise/src/queryable/queryable_wt \
+             src/mongo/db/modules/enterprise/src/sasl \
+             src/mongo/db/modules/enterprise/src/scripts \
+             src/mongo/db/modules/enterprise/src/serverless \
+             src/mongo/db/modules/enterprise/src/streams \
+             src/mongo/db/modules/enterprise/src/streams/commands \
+             src/mongo/db/modules/enterprise/src/streams/exec \
+             src/mongo/db/modules/enterprise/src/streams/exec/checkpoint \
+             src/mongo/db/modules/enterprise/src/streams/exec/tests \
+             src/mongo/db/modules/enterprise/src/streams/management \
+             src/mongo/db/modules/enterprise/src/streams/management/tests \
+             src/mongo/db/modules/enterprise/src/streams/tools \
+             src/mongo/db/modules/enterprise/src/streams/util \
+             src/mongo/db/modules/enterprise/src/streams/util/tests \
+             src/mongo/db/modules/enterprise/src/util \
+             src/mongo/db/modules/enterprise/src/workloads \
+             src/mongo/db/modules/enterprise/src/workloads/streams
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "enterprise_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "docs_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/docs/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "fle_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/docs/fle/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "testing_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/docs/testing/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "src_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/src/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "audit_commands_idl_gen", srcs = [])\nfilegroup(name = "audit_config_idl_gen", srcs = [])\nfilegroup(name = "audit_decryptor_options_idl_gen", srcs = [])\nfilegroup(name = "audit_event_type_idl_gen", srcs = [])\nfilegroup(name = "audit_global_hdrs", srcs = [])\nfilegroup(name = "audit_header_options_idl_gen", srcs = [])\nfilegroup(name = "audit_options_idl_gen", srcs = [])\n' > src/mongo/db/modules/enterprise/src/audit/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "logger_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/src/audit/logger/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "mongo_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/src/audit/mongo/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "ocsf_audit_events_idl_gen", srcs = [])\nfilegroup(name = "ocsf_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/src/audit/ocsf/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "decrypt_tool_options_idl_gen", srcs = [])\nfilegroup(name = "encryptdb_global_hdrs", srcs = [])\nfilegroup(name = "encryption_key_manager_idl_gen", srcs = [])\nfilegroup(name = "encryption_options_idl_gen", srcs = [])\nfilegroup(name = "keystore_metadata_idl_gen", srcs = [])\nfilegroup(name = "log_redact_options_idl_gen", srcs = [])\n' > src/mongo/db/modules/enterprise/src/encryptdb/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "fcbis_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/src/fcbis/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "fips_flag_client_idl_gen", srcs = [])\nfilegroup(name = "fips_flag_server_idl_gen", srcs = [])\nfilegroup(name = "fips_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/src/fips/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "fle_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/src/fle/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "commands_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/src/fle/commands/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "lib_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/src/fle/lib/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "query_analysis_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/src/fle/query_analysis/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "shell_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/src/fle/shell/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "backup_cursor_parameters_idl_gen", srcs = [])\nfilegroup(name = "document_source_backup_file_idl_gen", srcs = [])\nfilegroup(name = "hot_backups_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/src/hot_backups/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "inmemory_global_hdrs", srcs = [])\nfilegroup(name = "inmemory_global_options_idl_gen", srcs = [])\n' > src/mongo/db/modules/enterprise/src/inmemory/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "kerberos_global_hdrs", srcs = [])\nfilegroup(name = "kerberos_tool_options_idl_gen", srcs = [])\n' > src/mongo/db/modules/enterprise/src/kerberos/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "kmip_global_hdrs", srcs = [])\nfilegroup(name = "kmip_options_idl_gen", srcs = [])\n' > src/mongo/db/modules/enterprise/src/kmip/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "ldap_global_hdrs", srcs = [])\nfilegroup(name = "ldap_options_idl_gen", srcs = [])\nfilegroup(name = "ldap_options_mongod_idl_gen", srcs = [])\nfilegroup(name = "ldap_parameters_idl_gen", srcs = [])\nfilegroup(name = "ldap_runtime_parameters_idl_gen", srcs = [])\nfilegroup(name = "ldap_tool_options_idl_gen", srcs = [])\nfilegroup(name = "ldap_user_cache_poller_idl_gen", srcs = [])\n' > src/mongo/db/modules/enterprise/src/ldap/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "connections_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/src/ldap/connections/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "name_mapping_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/src/ldap/name_mapping/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "collection_properties_idl_gen", srcs = [])\nfilegroup(name = "live_import_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/src/live_import/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "commands_global_hdrs", srcs = [])\nfilegroup(name = "export_collection_idl_gen", srcs = [])\nfilegroup(name = "import_collection_idl_gen", srcs = [])\nfilegroup(name = "vote_commit_import_collection_idl_gen", srcs = [])\n' > src/mongo/db/modules/enterprise/src/live_import/commands/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "magic_restore_global_hdrs", srcs = [])\nfilegroup(name = "magic_restore_options_idl_gen", srcs = [])\nfilegroup(name = "magic_restore_structs_idl_gen", srcs = [])\n' > src/mongo/db/modules/enterprise/src/magic_restore/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "queryable_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/src/queryable/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "blockstore_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/src/queryable/blockstore/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "queryable_global_options_idl_gen", srcs = [])\nfilegroup(name = "queryable_wt_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/src/queryable/queryable_wt/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "auth_delay_idl_gen", srcs = [])\nfilegroup(name = "oidc_commands_idl_gen", srcs = [])\nfilegroup(name = "oidc_parameters_idl_gen", srcs = [])\nfilegroup(name = "sasl_aws_server_options_idl_gen", srcs = [])\nfilegroup(name = "sasl_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/src/sasl/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "scripts_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/src/scripts/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "mongoqd_options_idl_gen", srcs = [])\nfilegroup(name = "serverless_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/src/serverless/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "streams_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/src/streams/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "commands_global_hdrs", srcs = [])\nfilegroup(name = "stream_ops_idl_gen", srcs = [])\n' > src/mongo/db/modules/enterprise/src/streams/commands/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "checkpoint_data_idl_gen", srcs = [])\nfilegroup(name = "common_idl_gen", srcs = [])\nfilegroup(name = "config_idl_gen", srcs = [])\nfilegroup(name = "exec_global_hdrs", srcs = [])\nfilegroup(name = "exec_internal_idl_gen", srcs = [])\nfilegroup(name = "stages_idl_gen", srcs = [])\n' > src/mongo/db/modules/enterprise/src/streams/exec/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "checkpoint_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/src/streams/exec/checkpoint/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "tests_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/src/streams/exec/tests/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "management_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/src/streams/management/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "tests_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/src/streams/management/tests/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "tools_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/src/streams/tools/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "util_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/src/streams/util/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "tests_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/src/streams/util/tests/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "util_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/src/util/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "workloads_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/src/workloads/BUILD.bazel
+RUN printf 'package(default_visibility = ["//visibility:public"])\nfilegroup(name = "streams_global_hdrs", srcs = [])\n' > src/mongo/db/modules/enterprise/src/workloads/streams/BUILD.bazel
 
 # Install Bazelisk directly (handles correct Bazel version automatically)
 # This avoids needing MongoDB's install_bazel.py which has additional Python dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,16 @@
 # Based on https://github.com/alanedwardes/mongodb-without-avx
 # Updated for MongoDB 8.x with Bazel build system
 
-FROM ubuntu:20.04 AS build
+FROM debian:12 AS build
 
 # Install build dependencies for MongoDB 8.x with Bazel
-ENV DEBIAN_FRONTEND=noninteractive
-
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
         build-essential \
         ca-certificates \
         libcurl4-openssl-dev \
         liblzma-dev \
         libssl-dev \
-        python3-dev \
+        python-dev-is-python3 \
         python3-pip \
         python3-venv \
         lld \
@@ -173,10 +171,13 @@ RUN export GIT_PYTHON_REFRESH=quiet && \
         --config=local \
         --//bazel/config:build_enterprise=False \
         --disable_warnings_as_errors=True \
+        --//bazel/config:debug_symbols=False \
+        --//bazel/config:dbg=False \
         --action_env=SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
         --action_env=SSL_CERT_DIR=/etc/ssl/certs \
         --action_env=REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
         --action_env=CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
+        --action_env=LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libstdc++.so.6 \
         --define=MONGO_VERSION="${MONGO_VERSION}" \
         --define=GIT_COMMIT_HASH="0000000000000000000000000000000000000000" \
         ${JOBS_ARG} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -140,7 +140,7 @@ ENV PATH="/root/.local/bin:${PATH}"
 # Install Cheetah3 with its C extension for NameMapper, which is used by
 # Bazel's sandboxed Python actions during the build. Without the C extension
 # the build still works but emits a UserWarning about performance.
-RUN pip3 install --break-system-packages --no-cache-dir CT3
+RUN pip3 install --no-cache-dir CT3
 
 # Apply the no-AVX patch to disable sandybridge/AVX optimizations
 # The patch modifies bazel/toolchains/cc/mongo_linux/mongo_linux_cc_toolchain_config.bzl

--- a/Dockerfile
+++ b/Dockerfile
@@ -135,6 +135,11 @@ RUN mkdir -p /root/.local/bin && \
 
 ENV PATH="/root/.local/bin:${PATH}"
 
+# Install Cheetah3 with its C extension for NameMapper, which is used by
+# Bazel's sandboxed Python actions during the build. Without the C extension
+# the build still works but emits a UserWarning about performance.
+RUN pip3 install --break-system-packages --no-cache-dir CT3
+
 # Apply the no-AVX patch to disable sandybridge/AVX optimizations
 # The patch modifies bazel/toolchains/cc/mongo_linux/mongo_linux_cc_toolchain_config.bzl
 # to use -march=x86-64-v2 instead of -march=sandybridge

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,50 +1,22 @@
-# MongoDB without AVX
-# Based on https://github.com/alanedwardes/mongodb-without-avx
-# Updated for MongoDB 8.x with Bazel build system
+FROM debian:12 as build
 
-FROM debian:12 AS build
-
-# Install build dependencies for MongoDB 8.x with Bazel
-RUN apt-get update -y && apt-get install -y \
-        build-essential \
+RUN apt update -y && apt install -y build-essential \
         libcurl4-openssl-dev \
         liblzma-dev \
         libssl-dev \
         python-dev-is-python3 \
         python3-pip \
-        python3-venv \
-        lld \
         curl \
-        git \
-        pkg-config \
-        openjdk-17-jdk \
     && rm -rf /var/lib/apt/lists/*
 
-ARG MONGO_VERSION=8.0.19
+ARG MONGO_VERSION=6.2.1
 
-# Download MongoDB source
 RUN mkdir /src && \
     curl -o /tmp/mongo.tar.gz -L "https://github.com/mongodb/mongo/archive/refs/tags/r${MONGO_VERSION}.tar.gz" && \
     tar xaf /tmp/mongo.tar.gz --strip-components=1 -C /src && \
     rm /tmp/mongo.tar.gz
 
 WORKDIR /src
-
-# Create stub enterprise directory structure to satisfy build dependencies
-# MongoDB's open source build has references to enterprise paths that need to exist
-RUN mkdir -p src/mongo/db/modules/enterprise/src/workloads/streams && \
-    echo '# Stub BUILD file for community build' > src/mongo/db/modules/enterprise/BUILD.bazel && \
-    echo '# Stub BUILD file for community build' > src/mongo/db/modules/enterprise/src/BUILD.bazel && \
-    echo '# Stub BUILD file for community build' > src/mongo/db/modules/enterprise/src/workloads/BUILD.bazel && \
-    echo '# Stub BUILD file for community build' > src/mongo/db/modules/enterprise/src/workloads/streams/BUILD.bazel
-
-# Install Bazelisk directly (handles correct Bazel version automatically)
-# This avoids needing MongoDB's install_bazel.py which has additional Python dependencies
-RUN mkdir -p /root/.local/bin && \
-    curl -L -o /root/.local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.25.0/bazelisk-linux-amd64 && \
-    chmod +x /root/.local/bin/bazel
-
-ENV PATH="/root/.local/bin:${PATH}"
 
 # Apply the no-AVX patch to disable sandybridge/AVX optimizations
 # The patch modifies bazel/toolchains/cc/mongo_linux/mongo_linux_cc_toolchain_config.bzl
@@ -57,59 +29,95 @@ RUN sed -i 's/-march=sandybridge", "-mtune=generic", "-mprefer-vector-width=128/
 
 ARG NUM_JOBS=
 
-# Build MongoDB using Bazel
-# --config=local disables remote execution (required for building outside MongoDB's infra)
-# --//bazel/config:build_enterprise=False explicitly disables enterprise modules
 RUN export GIT_PYTHON_REFRESH=quiet && \
-    if [ -n "${NUM_JOBS}" ] && [ "${NUM_JOBS}" -gt 0 ]; then \
-        export JOBS_ARG="--jobs=${NUM_JOBS}"; \
-    fi && \
-    bazel build \
-        --config=local \
-        --//bazel/config:build_enterprise=False \
-        --disable_warnings_as_errors=True \
-        ${JOBS_ARG} \
-        //:install-mongod \
-        //:install-mongos
+    python3 -m pip install requirements_parser && \
+    python3 -m pip install -r etc/pip/compile-requirements.txt && \
+    if [ "${NUM_JOBS}" -gt 0 ]; then export JOBS_ARG="-j ${NUM_JOBS}"; fi && \
+    python3 buildscripts/scons.py install-devcore MONGO_VERSION="${MONGO_VERSION}" --release --disable-warnings-as-errors ${JOBS_ARG} && \
+    mv build/install /install && \
+    strip --strip-debug /install/bin/mongod && \
+    strip --strip-debug /install/bin/mongos && \
+    rm -rf build
 
-# Strip and prepare binaries
-RUN strip --strip-debug bazel-bin/install/bin/mongod && \
-    strip --strip-debug bazel-bin/install/bin/mongos && \
-    ls -la bazel-bin/install/bin/
+FROM debian:12
 
-# Final image
-FROM debian:12-slim
-
-# Install runtime dependencies
-RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
-        libcurl4 \
-        libssl3 \
-        liblzma5 \
-        ca-certificates \
-    && apt-get clean \
+RUN apt update -y && \
+    apt install -y libcurl4 && \
+    apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy MongoDB binaries
-COPY --from=build /src/bazel-bin/install/bin/mongod /usr/local/bin/
-COPY --from=build /src/bazel-bin/install/bin/mongos /usr/local/bin/
+COPY --from=build /install/bin/mongo* /usr/local/bin/
 
-# Create data directory with proper permissions
-RUN mkdir -p /data/db /data/configdb && \
-    chmod -R 750 /data && \
-    chown -R 999:999 /data
+# grab gosu for easy step-down from root (https://github.com/tianon/gosu/releases)
+ENV GOSU_VERSION 1.16
+# grab "js-yaml" for parsing mongod's YAML config files (https://github.com/nodeca/js-yaml/releases)
+ENV JSYAML_VERSION 3.13.1
 
-# Create mongodb user
-RUN groupadd -r mongodb --gid=999 && \
-    useradd -r -g mongodb --uid=999 mongodb
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		ca-certificates \
+		gnupg \
+		jq \
+		numactl \
+		procps \
+	; \
+	rm -rf /var/lib/apt/lists/*
 
-# Set volume for data persistence
-VOLUME ["/data/db", "/data/configdb"]
+RUN set -ex; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		wget \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	\
+	wget -O /js-yaml.js "https://github.com/nodeca/js-yaml/raw/${JSYAML_VERSION}/dist/js-yaml.js"; \
+# TODO some sort of download verification here
+	\
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark > /dev/null; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	\
+# smoke test
+	chmod +x /usr/local/bin/gosu; \
+	gosu --version; \
+	gosu nobody true
 
-# Expose MongoDB default port
-EXPOSE 27017
+RUN mkdir /docker-entrypoint-initdb.d
+#RUN mkdir -p /data/db && \
+#    chmod -R 750 /data && \
+#    chown -R 999:999 /data
+
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+RUN set -eux; \
+	groupadd --gid 999 --system mongodb; \
+	useradd --uid 999 --system --gid mongodb --home-dir /data/db mongodb; \
+	mkdir -p /data/db /data/configdb; \
+	chown -R mongodb:mongodb /data/db /data/configdb
 
 USER mongodb
 
-ENTRYPOINT ["/usr/local/bin/mongod"]
-CMD ["--bind_ip_all"]
+VOLUME /data/db /data/configdb
+
+# ensure that if running as custom user that "mongosh" has a valid "HOME"
+# https://github.com/docker-library/mongo/issues/524
+ENV HOME /data/db
+
+COPY docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+EXPOSE 27017
+CMD ["mongod"]
+
+#ENTRYPOINT [ "/usr/local/bin/mongod" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,60 +31,63 @@ RUN mkdir /src && \
 
 WORKDIR /src
 
-# Stub enterprise packages required by the community build.
-#
-# Even with --//bazel/config:build_enterprise=False, the analysis phase resolves
-# every package path referenced in BUILD files across the whole source tree.
-# Enterprise sub-packages are referenced but don't exist in the community tarball.
-#
-# Neither .bazelignore nor grep-based enumeration works reliably:
-#   - .bazelignore translates to --deleted_packages internally, which still errors
-#     when a BUILD file depends on a deleted package.
-#   - grep misses paths constructed dynamically in Starlark.
-#
-# Solution: run `bazel query` (analysis only, no compilation) in a retry loop.
-#   Each iteration collects every "no such package" error pointing at an enterprise
-#   path, creates a stub BUILD.bazel there, and retries until the query succeeds.
-#   This is guaranteed to terminate because each iteration stubs at least one new
-#   directory, and the total number of referenced packages is finite.
+# Create stub BUILD files for every enterprise sub-package referenced by
+# src/BUILD.bazel:core_headers_library_with_debug. These paths exist in the
+# enterprise repo but not in the community tarball. The list was extracted
+# directly from src/BUILD.bazel in MongoDB 8.0.19.
 RUN set -e; \
-    ENTERPRISE_ROOT="src/mongo/db/modules/enterprise"; \
     STUB='# Stub BUILD file for community build'; \
-    mkdir -p "${ENTERPRISE_ROOT}"; \
-    printf '%s\n' "${STUB}" > "${ENTERPRISE_ROOT}/BUILD.bazel"; \
-    \
-    QUERY_FLAGS=" \
-        --config=local \
-        --//bazel/config:build_enterprise=False \
-        --keep_going \
-        --output=label"; \
-    \
-    for attempt in $(seq 1 30); do \
-        echo "--- Stub attempt ${attempt} ---"; \
-        MISSING=$(bazel query ${QUERY_FLAGS} \
-            'deps(//:install-mongod) + deps(//:install-mongos)' 2>&1 \
-            | grep -oE "no such package '[^']+'" \
-            | grep -oE "'[^']+'" \
-            | tr -d "'" \
-            | grep 'enterprise' \
-            | sort -u) || true; \
-        \
-        if [ -z "${MISSING}" ]; then \
-            echo "All enterprise packages resolved after ${attempt} attempt(s)."; \
-            break; \
-        fi; \
-        \
-        echo "Stubbing missing packages:"; \
-        echo "${MISSING}"; \
-        echo "${MISSING}" | while IFS= read -r pkg; do \
-            dir="${pkg//\/\///}"; \
-            dir="$(echo "${pkg}" | tr ':' '/')"; \
-            mkdir -p "${dir}"; \
-            printf '%s\n' "${STUB}" > "${dir}/BUILD.bazel"; \
-        done; \
-    done; \
-    echo "Final enterprise stubs:"; \
-    find "${ENTERPRISE_ROOT}" -name BUILD.bazel | sort
+    for d in \
+        src/mongo/db/modules/enterprise \
+        src/mongo/db/modules/enterprise/docs \
+        src/mongo/db/modules/enterprise/docs/fle \
+        src/mongo/db/modules/enterprise/docs/testing \
+        src/mongo/db/modules/enterprise/src \
+        src/mongo/db/modules/enterprise/src/audit \
+        src/mongo/db/modules/enterprise/src/audit/logger \
+        src/mongo/db/modules/enterprise/src/audit/mongo \
+        src/mongo/db/modules/enterprise/src/audit/ocsf \
+        src/mongo/db/modules/enterprise/src/encryptdb \
+        src/mongo/db/modules/enterprise/src/fcbis \
+        src/mongo/db/modules/enterprise/src/fips \
+        src/mongo/db/modules/enterprise/src/fle \
+        src/mongo/db/modules/enterprise/src/fle/commands \
+        src/mongo/db/modules/enterprise/src/fle/lib \
+        src/mongo/db/modules/enterprise/src/fle/query_analysis \
+        src/mongo/db/modules/enterprise/src/fle/shell \
+        src/mongo/db/modules/enterprise/src/hot_backups \
+        src/mongo/db/modules/enterprise/src/inmemory \
+        src/mongo/db/modules/enterprise/src/kerberos \
+        src/mongo/db/modules/enterprise/src/kmip \
+        src/mongo/db/modules/enterprise/src/ldap \
+        src/mongo/db/modules/enterprise/src/ldap/connections \
+        src/mongo/db/modules/enterprise/src/ldap/name_mapping \
+        src/mongo/db/modules/enterprise/src/live_import \
+        src/mongo/db/modules/enterprise/src/live_import/commands \
+        src/mongo/db/modules/enterprise/src/magic_restore \
+        src/mongo/db/modules/enterprise/src/queryable \
+        src/mongo/db/modules/enterprise/src/queryable/blockstore \
+        src/mongo/db/modules/enterprise/src/queryable/queryable_wt \
+        src/mongo/db/modules/enterprise/src/sasl \
+        src/mongo/db/modules/enterprise/src/scripts \
+        src/mongo/db/modules/enterprise/src/serverless \
+        src/mongo/db/modules/enterprise/src/streams \
+        src/mongo/db/modules/enterprise/src/streams/commands \
+        src/mongo/db/modules/enterprise/src/streams/exec \
+        src/mongo/db/modules/enterprise/src/streams/exec/checkpoint \
+        src/mongo/db/modules/enterprise/src/streams/exec/tests \
+        src/mongo/db/modules/enterprise/src/streams/management \
+        src/mongo/db/modules/enterprise/src/streams/management/tests \
+        src/mongo/db/modules/enterprise/src/streams/tools \
+        src/mongo/db/modules/enterprise/src/streams/util \
+        src/mongo/db/modules/enterprise/src/streams/util/tests \
+        src/mongo/db/modules/enterprise/src/util \
+        src/mongo/db/modules/enterprise/src/workloads \
+        src/mongo/db/modules/enterprise/src/workloads/streams \
+    ; do \
+        mkdir -p "${d}"; \
+        printf '%s\n' "${STUB}" > "${d}/BUILD.bazel"; \
+    done
 
 # Install Bazelisk directly (handles correct Bazel version automatically)
 # This avoids needing MongoDB's install_bazel.py which has additional Python dependencies

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,408 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+if [ "${1:0:1}" = '-' ]; then
+	set -- mongod "$@"
+fi
+
+originalArgOne="$1"
+
+# allow the container to be started with `--user`
+# all mongo* commands should be dropped to the correct user
+if [[ "$originalArgOne" == mongo* ]] && [ "$(id -u)" = '0' ]; then
+	if [ "$originalArgOne" = 'mongod' ]; then
+		find /data/configdb /data/db \! -user mongodb -exec chown mongodb '{}' +
+	fi
+
+	# make sure we can write to stdout and stderr as "mongodb"
+	# (for our "initdb" code later; see "--logpath" below)
+	chown --dereference mongodb "/proc/$$/fd/1" "/proc/$$/fd/2" || :
+	# ignore errors thanks to https://github.com/docker-library/mongo/issues/149
+
+	exec gosu mongodb "$BASH_SOURCE" "$@"
+fi
+
+dpkgArch="$(dpkg --print-architecture)"
+case "$dpkgArch" in
+
+	arm64) # https://github.com/docker-library/mongo/issues/485#issuecomment-970864306
+		# https://en.wikichip.org/wiki/arm/armv8#ARMv8_Extensions_and_Processor_Features
+		# http://javathunderx.blogspot.com/2018/11/cheat-sheet-for-cpuinfo-features-on.html
+		if ! grep -qE '^Features.* (fphp|dcpop|sha3|sm3|sm4|asimddp|sha512|sve)( .*|$)' /proc/cpuinfo; then
+			{
+				echo
+				echo 'WARNING: MongoDB requires ARMv8.2-A or higher, and your current system does not appear to implement any of the common features for that!'
+				echo '  applies to all versions ≥5.0, any of 4.4 ≥4.4.19'
+				echo '  see https://jira.mongodb.org/browse/SERVER-71772'
+				echo '  see https://jira.mongodb.org/browse/SERVER-55178'
+				echo '  see also https://en.wikichip.org/wiki/arm/armv8#ARMv8_Extensions_and_Processor_Features'
+				echo '  see also https://github.com/docker-library/mongo/issues/485#issuecomment-970864306'
+				echo
+			} >&2
+		fi
+		;;
+esac
+
+# you should use numactl to start your mongod instances, including the config servers, mongos instances, and any clients.
+# https://docs.mongodb.com/manual/administration/production-notes/#configuring-numa-on-linux
+if [[ "$originalArgOne" == mongo* ]]; then
+	numa='numactl --interleave=all'
+	if $numa true &> /dev/null; then
+		set -- $numa "$@"
+	fi
+fi
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+# see https://github.com/docker-library/mongo/issues/147 (mongod is picky about duplicated arguments)
+_mongod_hack_have_arg() {
+	local checkArg="$1"; shift
+	local arg
+	for arg; do
+		case "$arg" in
+			"$checkArg"|"$checkArg"=*)
+				return 0
+				;;
+		esac
+	done
+	return 1
+}
+# _mongod_hack_get_arg_val '--some-arg' "$@"
+_mongod_hack_get_arg_val() {
+	local checkArg="$1"; shift
+	while [ "$#" -gt 0 ]; do
+		local arg="$1"; shift
+		case "$arg" in
+			"$checkArg")
+				echo "$1"
+				return 0
+				;;
+			"$checkArg"=*)
+				echo "${arg#$checkArg=}"
+				return 0
+				;;
+		esac
+	done
+	return 1
+}
+declare -a mongodHackedArgs
+# _mongod_hack_ensure_arg '--some-arg' "$@"
+# set -- "${mongodHackedArgs[@]}"
+_mongod_hack_ensure_arg() {
+	local ensureArg="$1"; shift
+	mongodHackedArgs=( "$@" )
+	if ! _mongod_hack_have_arg "$ensureArg" "$@"; then
+		mongodHackedArgs+=( "$ensureArg" )
+	fi
+}
+# _mongod_hack_ensure_no_arg '--some-unwanted-arg' "$@"
+# set -- "${mongodHackedArgs[@]}"
+_mongod_hack_ensure_no_arg() {
+	local ensureNoArg="$1"; shift
+	mongodHackedArgs=()
+	while [ "$#" -gt 0 ]; do
+		local arg="$1"; shift
+		if [ "$arg" = "$ensureNoArg" ]; then
+			continue
+		fi
+		mongodHackedArgs+=( "$arg" )
+	done
+}
+# _mongod_hack_ensure_no_arg '--some-unwanted-arg' "$@"
+# set -- "${mongodHackedArgs[@]}"
+_mongod_hack_ensure_no_arg_val() {
+	local ensureNoArg="$1"; shift
+	mongodHackedArgs=()
+	while [ "$#" -gt 0 ]; do
+		local arg="$1"; shift
+		case "$arg" in
+			"$ensureNoArg")
+				shift # also skip the value
+				continue
+				;;
+			"$ensureNoArg"=*)
+				# value is already included
+				continue
+				;;
+		esac
+		mongodHackedArgs+=( "$arg" )
+	done
+}
+# _mongod_hack_ensure_arg_val '--some-arg' 'some-val' "$@"
+# set -- "${mongodHackedArgs[@]}"
+_mongod_hack_ensure_arg_val() {
+	local ensureArg="$1"; shift
+	local ensureVal="$1"; shift
+	_mongod_hack_ensure_no_arg_val "$ensureArg" "$@"
+	mongodHackedArgs+=( "$ensureArg" "$ensureVal" )
+}
+
+# _js_escape 'some "string" value'
+_js_escape() {
+	jq --null-input --arg 'str' "$1" '$str'
+}
+
+: "${TMPDIR:=/tmp}"
+jsonConfigFile="$TMPDIR/docker-entrypoint-config.json"
+tempConfigFile="$TMPDIR/docker-entrypoint-temp-config.json"
+_parse_config() {
+	if [ -s "$tempConfigFile" ]; then
+		return 0
+	fi
+
+	local configPath
+	if configPath="$(_mongod_hack_get_arg_val --config "$@")" && [ -s "$configPath" ]; then
+		# if --config is specified, parse it into a JSON file so we can remove a few problematic keys (especially SSL-related keys)
+		# see https://docs.mongodb.com/manual/reference/configuration-options/
+		if grep -vEm1 '^[[:space:]]*(#|$)' "$configPath" | grep -qE '^[[:space:]]*[^=:]+[[:space:]]*='; then
+			# if the first non-comment/non-blank line of the config file looks like "foo = ...", this is probably the 2.4 and older "ini-style config format"
+			# mongod tries to parse config as yaml and then falls back to ini-style parsing
+			# https://github.com/mongodb/mongo/blob/r6.0.3/src/mongo/util/options_parser/options_parser.cpp#L1883-L1894
+			echo >&2
+			echo >&2 "WARNING: it appears that '$configPath' is in the older INI-style format (replaced by YAML in MongoDB 2.6)"
+			echo >&2 '  This script does not parse the older INI-style format, and thus will ignore it.'
+			echo >&2
+			return 1
+		fi
+		if [ "$mongoShell" = 'mongo' ]; then
+			"$mongoShell" --norc --nodb --quiet --eval "load('/js-yaml.js'); printjson(jsyaml.load(cat($(_js_escape "$configPath"))))" > "$jsonConfigFile"
+		else
+			# https://www.mongodb.com/docs/manual/reference/method/js-native/#std-label-native-in-mongosh
+			"$mongoShell" --norc --nodb --quiet --eval "load('/js-yaml.js'); JSON.stringify(jsyaml.load(fs.readFileSync($(_js_escape "$configPath"), 'utf8')))" > "$jsonConfigFile"
+		fi
+		if [ "$(head -c1 "$jsonConfigFile")" != '{' ] || [ "$(tail -c2 "$jsonConfigFile")" != '}' ]; then
+			# if the file doesn't start with "{" and end with "}", it's *probably* an error ("uncaught exception: YAMLException: foo" for example), so we should print it out
+			echo >&2 'error: unexpected "js-yaml.js" output while parsing config:'
+			cat >&2 "$jsonConfigFile"
+			exit 1
+		fi
+		jq 'del(.systemLog, .processManagement, .net, .security, .replication)' "$jsonConfigFile" > "$tempConfigFile"
+		return 0
+	fi
+
+	return 1
+}
+dbPath=
+_dbPath() {
+	if [ -n "$dbPath" ]; then
+		echo "$dbPath"
+		return
+	fi
+
+	if ! dbPath="$(_mongod_hack_get_arg_val --dbpath "$@")"; then
+		if _parse_config "$@"; then
+			dbPath="$(jq -r '.storage.dbPath // empty' "$jsonConfigFile")"
+		fi
+	fi
+
+	if [ -z "$dbPath" ]; then
+		if _mongod_hack_have_arg --configsvr "$@" || {
+			_parse_config "$@" \
+			&& clusterRole="$(jq -r '.sharding.clusterRole // empty' "$jsonConfigFile")" \
+			&& [ "$clusterRole" = 'configsvr' ]
+		}; then
+			# if running as config server, then the default dbpath is /data/configdb
+			# https://docs.mongodb.com/manual/reference/program/mongod/#cmdoption-mongod-configsvr
+			dbPath=/data/configdb
+		fi
+	fi
+
+	: "${dbPath:=/data/db}"
+
+	echo "$dbPath"
+}
+
+if [ "$originalArgOne" = 'mongod' ]; then
+	file_env 'MONGO_INITDB_ROOT_USERNAME'
+	file_env 'MONGO_INITDB_ROOT_PASSWORD'
+
+	mongoShell='mongo'
+	if ! command -v "$mongoShell" > /dev/null; then
+		mongoShell='mongosh'
+	fi
+
+	# pre-check a few factors to see if it's even worth bothering with initdb
+	shouldPerformInitdb=
+	if [ "$MONGO_INITDB_ROOT_USERNAME" ] && [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
+		# if we have a username/password, let's set "--auth"
+		_mongod_hack_ensure_arg '--auth' "$@"
+		set -- "${mongodHackedArgs[@]}"
+		shouldPerformInitdb='true'
+	elif [ "$MONGO_INITDB_ROOT_USERNAME" ] || [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
+		cat >&2 <<-'EOF'
+
+			error: missing 'MONGO_INITDB_ROOT_USERNAME' or 'MONGO_INITDB_ROOT_PASSWORD'
+			       both must be specified for a user to be created
+
+		EOF
+		exit 1
+	fi
+
+	if [ -z "$shouldPerformInitdb" ]; then
+		# if we've got any /docker-entrypoint-initdb.d/* files to parse later, we should initdb
+		for f in /docker-entrypoint-initdb.d/*; do
+			case "$f" in
+				*.sh|*.js) # this should match the set of files we check for below
+					shouldPerformInitdb="$f"
+					break
+					;;
+			esac
+		done
+	fi
+
+	# check for a few known paths (to determine whether we've already initialized and should thus skip our initdb scripts)
+	if [ -n "$shouldPerformInitdb" ]; then
+		dbPath="$(_dbPath "$@")"
+		for path in \
+			"$dbPath/WiredTiger" \
+			"$dbPath/journal" \
+			"$dbPath/local.0" \
+			"$dbPath/storage.bson" \
+		; do
+			if [ -e "$path" ]; then
+				shouldPerformInitdb=
+				break
+			fi
+		done
+	fi
+
+	if [ -n "$shouldPerformInitdb" ]; then
+		mongodHackedArgs=( "$@" )
+		if _parse_config "$@"; then
+			_mongod_hack_ensure_arg_val --config "$tempConfigFile" "${mongodHackedArgs[@]}"
+		fi
+		_mongod_hack_ensure_arg_val --bind_ip 127.0.0.1 "${mongodHackedArgs[@]}"
+		_mongod_hack_ensure_arg_val --port 27017 "${mongodHackedArgs[@]}"
+		_mongod_hack_ensure_no_arg --bind_ip_all "${mongodHackedArgs[@]}"
+
+		# remove "--auth" and "--replSet" for our initial startup (see https://docs.mongodb.com/manual/tutorial/enable-authentication/#start-mongodb-without-access-control)
+		# https://github.com/docker-library/mongo/issues/211
+		_mongod_hack_ensure_no_arg --auth "${mongodHackedArgs[@]}"
+		# "keyFile implies security.authorization"
+		# https://docs.mongodb.com/manual/reference/configuration-options/#mongodb-setting-security.keyFile
+		_mongod_hack_ensure_no_arg_val --keyFile "${mongodHackedArgs[@]}"
+		if [ "$MONGO_INITDB_ROOT_USERNAME" ] && [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
+			_mongod_hack_ensure_no_arg_val --replSet "${mongodHackedArgs[@]}"
+		fi
+
+		# "BadValue: need sslPEMKeyFile when SSL is enabled" vs "BadValue: need to enable SSL via the sslMode flag when using SSL configuration parameters"
+		tlsMode='disabled'
+		if _mongod_hack_have_arg '--tlsCertificateKeyFile' "$@"; then
+			tlsMode='allowTLS'
+		fi
+		_mongod_hack_ensure_arg_val --tlsMode "$tlsMode" "${mongodHackedArgs[@]}"
+
+		if stat "/proc/$$/fd/1" > /dev/null && [ -w "/proc/$$/fd/1" ]; then
+			# https://github.com/mongodb/mongo/blob/38c0eb538d0fd390c6cb9ce9ae9894153f6e8ef5/src/mongo/db/initialize_server_global_state.cpp#L237-L251
+			# https://github.com/docker-library/mongo/issues/164#issuecomment-293965668
+			_mongod_hack_ensure_arg_val --logpath "/proc/$$/fd/1" "${mongodHackedArgs[@]}"
+		else
+			initdbLogPath="$(_dbPath "$@")/docker-initdb.log"
+			echo >&2 "warning: initdb logs cannot write to '/proc/$$/fd/1', so they are in '$initdbLogPath' instead"
+			_mongod_hack_ensure_arg_val --logpath "$initdbLogPath" "${mongodHackedArgs[@]}"
+		fi
+		_mongod_hack_ensure_arg --logappend "${mongodHackedArgs[@]}"
+
+		pidfile="$TMPDIR/docker-entrypoint-temp-mongod.pid"
+		rm -f "$pidfile"
+		_mongod_hack_ensure_arg_val --pidfilepath "$pidfile" "${mongodHackedArgs[@]}"
+
+		"${mongodHackedArgs[@]}" --fork
+
+		mongo=( "$mongoShell" --host 127.0.0.1 --port 27017 --quiet )
+
+		# check to see that our "mongod" actually did start up (catches "--help", "--version", slow prealloc, etc)
+		# https://jira.mongodb.org/browse/SERVER-16292
+		tries=30
+		while true; do
+			if ! { [ -s "$pidfile" ] && ps "$(< "$pidfile")" &> /dev/null; }; then
+				# bail ASAP if "mongod" isn't even running
+				echo >&2
+				echo >&2 "error: $originalArgOne does not appear to have stayed running -- perhaps it had an error?"
+				echo >&2
+				exit 1
+			fi
+			if "${mongo[@]}" 'admin' --eval 'quit(0)' &> /dev/null; then
+				# success!
+				break
+			fi
+			(( tries-- ))
+			if [ "$tries" -le 0 ]; then
+				echo >&2
+				echo >&2 "error: $originalArgOne does not appear to have accepted connections quickly enough -- perhaps it had an error?"
+				echo >&2
+				exit 1
+			fi
+			sleep 1
+		done
+
+		if [ "$MONGO_INITDB_ROOT_USERNAME" ] && [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
+			rootAuthDatabase='admin'
+
+			"${mongo[@]}" "$rootAuthDatabase" <<-EOJS
+				db.createUser({
+					user: $(_js_escape "$MONGO_INITDB_ROOT_USERNAME"),
+					pwd: $(_js_escape "$MONGO_INITDB_ROOT_PASSWORD"),
+					roles: [ { role: 'root', db: $(_js_escape "$rootAuthDatabase") } ]
+				})
+			EOJS
+		fi
+
+		export MONGO_INITDB_DATABASE="${MONGO_INITDB_DATABASE:-test}"
+
+		echo
+		for f in /docker-entrypoint-initdb.d/*; do
+			case "$f" in
+				*.sh) echo "$0: running $f"; . "$f" ;;
+				*.js) echo "$0: running $f"; "${mongo[@]}" "$MONGO_INITDB_DATABASE" "$f"; echo ;;
+				*)    echo "$0: ignoring $f" ;;
+			esac
+			echo
+		done
+
+		"${mongodHackedArgs[@]}" --shutdown
+		rm -f "$pidfile"
+
+		echo
+		echo 'MongoDB init process complete; ready for start up.'
+		echo
+	fi
+
+	# MongoDB defaults to localhost-only binding
+	haveBindIp=
+	if _mongod_hack_have_arg --bind_ip "$@" || _mongod_hack_have_arg --bind_ip_all "$@"; then
+		haveBindIp=1
+	elif _parse_config "$@" && jq --exit-status '.net.bindIp // .net.bindIpAll' "$jsonConfigFile" > /dev/null; then
+		haveBindIp=1
+	fi
+	if [ -z "$haveBindIp" ]; then
+		# so if no "--bind_ip" is specified, let's add "--bind_ip_all"
+		set -- "$@" --bind_ip_all
+	fi
+
+	unset "${!MONGO_INITDB_@}"
+fi
+
+rm -f "$jsonConfigFile" "$tempConfigFile"
+
+exec "$@"

--- a/mongo7_patch.diff
+++ b/mongo7_patch.diff
@@ -1,0 +1,25 @@
+--- a/src/third_party/mozjs/SConscript
++++ b/src/third_party/mozjs/SConscript
+@@ -145,8 +145,7 @@ sources = [
+ ]
+ 
+ if env['TARGET_ARCH'] == 'x86_64' and not env.TargetOSIs('windows'):
+-    env.Append(CCFLAGS=['-mavx2'])
+-    sources.extend(["extract/mozglue/misc/SIMD_avx2.cpp", "extract/mozglue/misc/SSE.cpp"])
++    sources.extend(["extract/mozglue/misc/SSE.cpp"])
+ 
+ if env.TargetOSIs('windows'):
+     sources.extend([
+diff --git a/src/third_party/mozjs/extract/mozglue/misc/SIMD.cpp b/src/third_party/mozjs/extract/mozglue/misc/SIMD.cpp
+index 3893de57b32..4ea0a657fbb 100644
+--- a/src/third_party/mozjs/extract/mozglue/misc/SIMD.cpp
++++ b/src/third_party/mozjs/extract/mozglue/misc/SIMD.cpp
+@@ -448,7 +448,7 @@ const char* SIMD::memchr8SSE2(const char* ptr, char value, size_t length) {
+ // assertion failure. Accordingly, we just don't allow that to happen. We
+ // are not particularly concerned about ensuring that newer 32 bit processors
+ // get access to the AVX2 functions exposed here.
+-#  if defined(MOZILLA_MAY_SUPPORT_AVX2) && defined(__x86_64__)
++#  if 0
+ 
+ bool SupportsAVX2() { return supports_avx2(); }
+ 

--- a/mongo8_patch.diff
+++ b/mongo8_patch.diff
@@ -1,0 +1,100 @@
+diff --git a/SConstruct b/SConstruct
+index e9aa2ca0b16..c965482f5cd 100644
+--- a/SConstruct
++++ b/SConstruct
+@@ -316,7 +316,7 @@ add_option(
+     'dbg',
+     choices=['on', 'off'],
+     const='on',
+-    default=build_profile.dbg,
++    default='off',
+     help='Enable runtime debugging checks',
+     nargs='?',
+     type='choice',
+@@ -353,7 +353,7 @@ add_option(
+     'opt',
+     choices=['on', 'debug', 'size', 'off', 'auto'],
+     const='on',
+-    default=build_profile.opt,
++    default='on',
+     help='Enable compile-time optimization',
+     nargs='?',
+     type='choice',
+@@ -379,7 +379,7 @@ add_option(
+     action="append",
+     choices=experimental_optimization_choices,
+     const=experimental_optimization_choices[0],
+-    default=['+sandybridge'],
++    default=[],
+     help='Enable experimental optimizations',
+     nargs='?',
+     type='choice',
+diff --git a/src/third_party/abseil-cpp/dist/absl/copts/GENERATED_AbseilCopts.cmake b/src/third_party/abseil-cpp/dist/absl/copts/GENERATED_AbseilCopts.cmake
+index 430916f726d..d0b613e990e 100644
+--- a/src/third_party/abseil-cpp/dist/absl/copts/GENERATED_AbseilCopts.cmake
++++ b/src/third_party/abseil-cpp/dist/absl/copts/GENERATED_AbseilCopts.cmake
+@@ -225,5 +225,5 @@ list(APPEND ABSL_RANDOM_HWAES_MSVC_X64_FLAGS
+
+ list(APPEND ABSL_RANDOM_HWAES_X64_FLAGS
+     "-maes"
+-    "-msse4.1"
++    "-msse3"
+ )
+diff --git a/src/third_party/abseil-cpp/dist/absl/copts/copts.py b/src/third_party/abseil-cpp/dist/absl/copts/copts.py
+index e6e119492c6..0fe278a14b7 100644
+--- a/src/third_party/abseil-cpp/dist/absl/copts/copts.py
++++ b/src/third_party/abseil-cpp/dist/absl/copts/copts.py
+@@ -185,7 +185,7 @@ COPT_VARS = {
+     "ABSL_RANDOM_HWAES_ARM32_FLAGS": ["-mfpu=neon"],
+     "ABSL_RANDOM_HWAES_X64_FLAGS": [
+         "-maes",
+-        "-msse4.1",
++        "-msse3",
+     ],
+     "ABSL_RANDOM_HWAES_MSVC_X64_FLAGS": [],
+ }
+diff --git a/src/third_party/mozjs/SConscript b/src/third_party/mozjs/SConscript
+index 56e9c78e4f9..f5bb91158ad 100644
+--- a/src/third_party/mozjs/SConscript
++++ b/src/third_party/mozjs/SConscript
+@@ -147,8 +147,7 @@ sources = [
+ ]
+
+ if env['TARGET_ARCH'] == 'x86_64' and not env.TargetOSIs('windows'):
+-    env.Append(CCFLAGS=['-mavx2'])
+-    sources.extend(["extract/mozglue/misc/SIMD_avx2.cpp", "extract/mozglue/misc/SSE.cpp"])
++    sources.extend(["extract/mozglue/misc/SSE.cpp"])
+
+ if env.TargetOSIs('windows'):
+     sources.extend([
+diff --git a/src/third_party/mozjs/extract/mozglue/misc/SIMD.cpp b/src/third_party/mozjs/extract/mozglue/misc/SIMD.cpp
+index 3893de57b32..7db5a669305 100644
+--- a/src/third_party/mozjs/extract/mozglue/misc/SIMD.cpp
++++ b/src/third_party/mozjs/extract/mozglue/misc/SIMD.cpp
+@@ -448,7 +448,8 @@ const char* SIMD::memchr8SSE2(const char* ptr, char value, size_t length) {
+ // assertion failure. Accordingly, we just don't allow that to happen. We
+ // are not particularly concerned about ensuring that newer 32 bit processors
+ // get access to the AVX2 functions exposed here.
+-#  if defined(MOZILLA_MAY_SUPPORT_AVX2) && defined(__x86_64__)
++#if 0
++//#  if defined(MOZILLA_MAY_SUPPORT_AVX2) && defined(__x86_64__)
+
+ bool SupportsAVX2() { return supports_avx2(); }
+
+diff --git a/src/third_party/snappy/platform/build_linux_x86_64/config.h b/src/third_party/snappy/platform/build_linux_x86_64/config.h
+index 94af08ae0d5..6ce366a191c 100644
+--- a/src/third_party/snappy/platform/build_linux_x86_64/config.h
++++ b/src/third_party/snappy/platform/build_linux_x86_64/config.h
+@@ -44,10 +44,10 @@
+ #define HAVE_WINDOWS_H 0
+
+ /* Define to 1 if you target processors with SSSE3+ and have <tmmintrin.h>. */
+-#define SNAPPY_HAVE_SSSE3 1
++#define SNAPPY_HAVE_SSSE3 0
+
+ /* Define to 1 if you target processors with SSE4.2 and have <crc32intrin.h>. */
+-#define SNAPPY_HAVE_X86_CRC32 1
++#define SNAPPY_HAVE_X86_CRC32 0
+
+ /* Define to 1 if you target processors with BMI2+ and have <bmi2intrin.h>. */
+ #define SNAPPY_HAVE_BMI2 0


### PR DESCRIPTION
Hello,

Not sure if you're interested, but I wanted to replace the container image I had with 4.4 to a 5.x, but the Dockerfile from your repository was diverging a bit too far from the one of the official Mongo image.
Thus I couldn't do a drop-in replacement.

If this is not desired, I'm ok to close this, I'll keep it in my fork.

It also updates the workflow to build and push images to Docker hub, you need to set two secrets in your repository:
```raw
DOCKER_HUB_USER
DOCKER_HUB_TOKEN
```

This Docker hub push could be made optional if not desirable.